### PR TITLE
No throw on not supported style selctor

### DIFF
--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -1,65 +1,84 @@
 ﻿using System;
 using Fizzler.Systems.HtmlAgilityPack;
 using HtmlAgilityPack;
+using System.Collections.Generic;
 
 namespace PreMailer.Net
 {
-	public class PreMailer
-	{
-		/// <summary>
-		/// Moves the CSS embedded in the specified htmlInput to inline style attributes.
-		/// </summary>
-		/// <param name="htmlInput">The HTML input.</param>
-		/// <param name="removeStyleElements">if set to <c>true</c> the style elements are removed.</param>
-		/// <returns>Returns the html input, with styles moved to inline attributes.</returns>
-		public string MoveCssInline(string htmlInput, bool removeStyleElements)
-		{
-			HtmlDocument doc = new HtmlDocument();
-			doc.LoadHtml(htmlInput);
+    public class PreMailer
+    {
 
-			var styleNodes = doc.DocumentNode.SelectNodes("//style");
+        /// <summary>
+        /// Moves the CSS embedded in the specified htmlInput to inline style attributes.
+        /// </summary>
+        /// <param name="htmlInput">The HTML input.</param>
+        /// <param name="removeStyleElements">if set to <c>true</c> the style elements are removed.</param>
+        /// <returns>Returns the html input, with styles moved to inline attributes.</returns>
+        public string MoveCssInline(string htmlInput, bool removeStyleElements)
+        {
+            return MoveCssInline(htmlInput, removeStyleElements, true);
+        }
 
-			foreach (var style in styleNodes)
-			{
-				if (style.Attributes["id"] != null && !String.IsNullOrWhiteSpace(style.Attributes["id"].Value) && style.Attributes["id"].Value.Equals("mobile", StringComparison.InvariantCultureIgnoreCase))
-				{
-					continue;
-				}
+        /// <summary>
+        /// Moves the CSS embedded in the specified htmlInput to inline style attributes.
+        /// </summary>
+        /// <param name="htmlInput">The HTML input.</param>
+        /// <param name="removeStyleElements">if set to <c>true</c> the style elements are removed.</param>
+        /// <param name="throwOnNotSupported">if set to <c>false</c> the not supported styles will be ignored.</param>
+        /// <returns>Returns the html input, with styles moved to inline attributes.</returns>
+        public string MoveCssInline(string htmlInput, bool removeStyleElements, bool throwOnNotSupported)
+        {
+            HtmlDocument doc = new HtmlDocument();
+            doc.LoadHtml(htmlInput);
 
-				CssParser cssParser = new CssParser();
-				string cssBlock = style.InnerHtml;
+            var styleNodes = doc.DocumentNode.SelectNodes("//style");
+            if (styleNodes != null)
+            {
+                foreach (var style in styleNodes)
+                {
+                    if (style.Attributes["id"] != null && !String.IsNullOrWhiteSpace(style.Attributes["id"].Value) && style.Attributes["id"].Value.Equals("mobile", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        continue;
+                    }
 
-				cssParser.AddStyleSheet(cssBlock);
+                    CssParser cssParser = new CssParser();
+                    string cssBlock = style.InnerHtml;
 
-				foreach (var item in cssParser.Styles)
-				{
-					var styleClass = item.Value;
-					var elements = doc.DocumentNode.QuerySelectorAll(styleClass.Name);
+                    cssParser.AddStyleSheet(cssBlock);
 
-					foreach (var element in elements)
-					{
-						HtmlAttribute styleAttribute = element.Attributes["style"];
+                    foreach (var item in cssParser.Styles)
+                    {
+                        var styleClass = item.Value;
 
-						if (styleAttribute == null)
-						{
-							element.Attributes.Add("style", String.Empty);
-							styleAttribute = element.Attributes["style"];
-						}
+                        IEnumerable<HtmlNode> elements = System.Linq.Enumerable.Empty<HtmlNode>();
+                        try { elements = doc.DocumentNode.QuerySelectorAll(styleClass.Name); }
+                        catch (FormatException ex) { if (throwOnNotSupported) throw ex; }
 
-						StyleClass sc = cssParser.ParseStyleClass("dummy", styleAttribute.Value);
-						sc.Merge(styleClass, false);
+                        foreach (var element in elements)
+                        {
+                            HtmlAttribute styleAttribute = element.Attributes["style"];
 
-						styleAttribute.Value = sc.ToString();
-					}
-				}
+                            if (styleAttribute == null)
+                            {
+                                element.Attributes.Add("style", String.Empty);
+                                styleAttribute = element.Attributes["style"];
+                            }
 
-				if (removeStyleElements)
-				{
-					style.Remove();
-				}
-			}
+                            StyleClass sc = cssParser.ParseStyleClass("dummy", styleAttribute.Value);
+                            sc.Merge(styleClass, false);
 
-			return doc.DocumentNode.OuterHtml;
-		}
-	}
+                            styleAttribute.Value = sc.ToString();
+                        }
+                    }
+
+                    if (removeStyleElements)
+                    {
+                        style.Remove();
+                    }
+                }
+            }
+
+            return doc.DocumentNode.OuterHtml;
+        }
+    }
 }


### PR DESCRIPTION
Fizzler does not support many css speudo classes.

I have some speudo classes in my css but there are not required for emails

I propose to simply ignore the FormatException thrown by Fizzler, it is not the best way, but it is quick to implement.
