### PR TITLE
NullReferenceException if no <style>-elements

### DIFF
--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -19,6 +19,8 @@ namespace PreMailer.Net
 
 			var styleNodes = doc.DocumentNode.SelectNodes("//style");
 
+			if (styleNodes == null) return htmlInput; // no styles to move
+
 			foreach (var style in styleNodes)
 			{
 				if (style.Attributes["id"] != null && !String.IsNullOrWhiteSpace(style.Attributes["id"].Value) && style.Attributes["id"].Value.Equals("mobile", StringComparison.InvariantCultureIgnoreCase))


### PR DESCRIPTION
It shouldn't fail if there aren't any style elements, but simply return the input unchanged. I've proposed a simple fix.
