### PR TITLE
Correct Specificity Score to Concat As String Rather Than Add as Int

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/CssSelectorParserTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssSelectorParserTests.cs
@@ -87,6 +87,13 @@ namespace PreMailer.Net.Tests
 		[TestMethod]
 		public void GetSelectorSpecificity_OneIdAndElementInPsuedoElement_Returns101()
 		{
+			var result = _parser.GetSelectorSpecificity("#s12:after");
+			Assert.AreEqual(101, result);
+		}
+
+		[TestMethod]
+		public void GetSelectorSpecificity_OneIdAndElementInNotPsuedoClass_Returns101()
+		{
 			var result = _parser.GetSelectorSpecificity("#s12:not(FOO)");
 			Assert.AreEqual(101, result);
 		}
@@ -103,6 +110,13 @@ namespace PreMailer.Net.Tests
 		{
 			var result = _parser.GetSelectorSpecificity("#id #id #id #id #id #id #id #id #id #id .class element");
 			Assert.AreEqual(1011, result);
+		}
+
+		[TestMethod]
+		public void GetSelectorSpecificity_ElementWithPsuedoClass_Returns11()
+		{
+			var result = _parser.GetSelectorSpecificity("li:first-child");
+			Assert.AreEqual(11, result);
 		}
 
 		[TestMethod]

--- a/PreMailer.Net/PreMailer.Net.Tests/CssSelectorTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssSelectorTests.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PreMailer.Net.Tests
+{
+	[TestClass]
+	public class CssSelectorTests
+	{
+		[TestMethod]
+		public void ContainsNotPsuedoClass_ElementWithPsuedoClass_ReturnsFalse()
+		{
+			var selector = new CssSelector("li:first-child");
+			Assert.IsFalse(selector.HasNotPsuedoClass);
+		}
+		
+		[TestMethod]
+		public void ContainsNotPsuedoClass_ElementWithNotPsuedoClass_ReturnsTrue()
+		{
+			var selector = new CssSelector("li:not(.ignored)");
+			Assert.IsTrue(selector.HasNotPsuedoClass);
+		}
+		
+		[TestMethod]
+		public void NotPsuedoClassContent_ElementWithPsuedoClass_ReturnsNull()
+		{
+			var selector = new CssSelector("li:first-child");
+			Assert.IsNull(selector.NotPsuedoClassContent);
+		}
+		
+		[TestMethod]
+		public void NotPsuedoClassContent_ElementWithNotPsuedoClass_ReturnsContent()
+		{
+			var selector = new CssSelector("li:not(.ignored)");
+			Assert.AreEqual(".ignored", selector.NotPsuedoClassContent);
+		}
+		
+		[TestMethod]
+		public void StripNotPsuedoClassContent_ElementWithPsuedoClass_ReturnsOriginalSelector()
+		{
+			var expected = "li:first-child";
+			var selector = new CssSelector(expected);
+			Assert.AreEqual(expected, selector.StripNotPsuedoClassContent().ToString());
+		}
+		
+		[TestMethod]
+		public void StripNotPsuedoClassContent_ElementWithNotPsuedoClass_ReturnsSelectorWithoutNot()
+		{
+			var selector = new CssSelector("li:not(.ignored)");
+			Assert.AreEqual("li", selector.StripNotPsuedoClassContent().ToString());
+		}
+	}
+}

--- a/PreMailer.Net/PreMailer.Net.Tests/CssSpecificityTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssSpecificityTests.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PreMailer.Net.Tests
+{
+	[TestClass]
+	public class CssSpecificityTests
+	{
+		[TestMethod]
+		public void PlusOperator_OneIdForBothInstances_ReturnsTwoIds()
+		{
+			var first = new CssSpecificity(1, 0, 0);
+			var second = new CssSpecificity(1, 0, 0);
+			var result = first + second;
+			Assert.AreEqual(2, result.Ids);
+		}
+		
+		[TestMethod]
+		public void PlusOperator_OneClassForBothInstances_ReturnsTwoClasses()
+		{
+			var first = new CssSpecificity(0, 1, 0);
+			var second = new CssSpecificity(0, 1, 0);
+			var result = first + second;
+			Assert.AreEqual(2, result.Classes);
+		}
+		
+		[TestMethod]
+		public void PlusOperator_OneElementForBothInstances_ReturnsTwoElements()
+		{
+			var first = new CssSpecificity(0, 0, 1);
+			var second = new CssSpecificity(0, 0, 1);
+			var result = first + second;
+			Assert.AreEqual(2, result.Elements);
+		}
+	}
+}

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailer.Net.Tests.csproj
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailer.Net.Tests.csproj
@@ -54,6 +54,8 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="CssSelectorParserTests.cs" />
+    <Compile Include="CssSelectorTests.cs" />
+    <Compile Include="CssSpecificityTests.cs" />
     <Compile Include="PreMailerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/PreMailer.Net/PreMailer.Net/CssSelector.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSelector.cs
@@ -1,0 +1,44 @@
+﻿using System.Text.RegularExpressions;
+
+namespace PreMailer.Net
+{
+	public class CssSelector
+	{
+		protected static Regex NotMatcher = new Regex(@":not\((.+)\)", RegexOptions.IgnoreCase & RegexOptions.Compiled);
+
+		public string Selector { get; protected set; }
+
+		public bool HasNotPsuedoClass
+		{
+			get
+			{
+				return NotMatcher.IsMatch(Selector);
+			}
+		}
+		
+		public string NotPsuedoClassContent
+		{
+			get
+			{
+				var match = NotMatcher.Match(Selector);
+				return match.Success ? match.Groups[1].Value : null;
+			}
+		}
+
+		public CssSelector(string selector)
+		{
+			Selector = selector;
+		}
+
+		public CssSelector StripNotPsuedoClassContent()
+		{
+			var stripped = NotMatcher.Replace(Selector, string.Empty);
+			return new CssSelector(stripped);
+		}
+
+		public override string ToString()
+		{
+			return Selector;
+		}
+	}
+}

--- a/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace PreMailer.Net
@@ -8,16 +10,18 @@ namespace PreMailer.Net
 		private readonly Regex _idMatcher;
 		private readonly Regex _attribMatcher;
 		private readonly Regex _classMatcher;
-		private readonly Regex _psuedoMatcher;
+		private readonly Regex _psuedoClassMatcher;
 		private readonly Regex _elemMatcher;
+		private readonly Regex _psuedoElemMatcher;
 
 		public CssSelectorParser()
 		{
 			_idMatcher = new Regex(@"#([\w]+)", RegexOptions.Compiled & RegexOptions.IgnoreCase);
 			_attribMatcher = new Regex(@"\[[\w=]+\]", RegexOptions.Compiled & RegexOptions.IgnoreCase);
 			_classMatcher = new Regex(@"\.([\w]+)", RegexOptions.Compiled & RegexOptions.IgnoreCase);
-			_psuedoMatcher = new Regex(@":\w+", RegexOptions.Compiled & RegexOptions.IgnoreCase);
+			_psuedoClassMatcher = BuildPsuedoClassesRegex();
 			_elemMatcher = new Regex(@"[a-zA-Z]+", RegexOptions.Compiled & RegexOptions.IgnoreCase);
+			_psuedoElemMatcher = BuildPsuedoElementsRegex();
 		}
 
 		/// <summary>
@@ -40,31 +44,33 @@ namespace PreMailer.Net
 		/// <returns>Specificity score of the given selector.</returns>
 		public int GetSelectorSpecificity(string selector)
 		{
-			if (string.IsNullOrWhiteSpace(selector) || selector == "*")
-				return 0;
+			return CalculateSpecificity(selector).ToInt();
+		}
 
-			var buffer = selector;
+		public CssSpecificity CalculateSpecificity(string selector)
+		{
+			if (string.IsNullOrWhiteSpace(selector) || selector == "*")
+				return CssSpecificity.None;
+
+			var cssSelector = new CssSelector(selector);
+
+			var result = CssSpecificity.None;
+			if (cssSelector.HasNotPsuedoClass)
+			{
+				result += CalculateSpecificity(cssSelector.NotPsuedoClassContent);
+			}
+
+			var buffer = cssSelector.StripNotPsuedoClassContent().ToString();
 
 			var ids = MatchCountAndStrip(_idMatcher, buffer, out buffer);
 			var attributes = MatchCountAndStrip(_attribMatcher, buffer, out buffer);
 			var classes = MatchCountAndStrip(_classMatcher, buffer, out buffer);
-			var psuedo = MatchCountAndStrip(_psuedoMatcher, buffer, out buffer); // Psuedo Classes Are Ignored..
+			var psuedoClasses = MatchCountAndStrip(_psuedoClassMatcher, buffer, out buffer);
 			var elementNames = MatchCountAndStrip(_elemMatcher, buffer, out buffer);
+			var psuedoElems = MatchCountAndStrip(_psuedoElemMatcher, buffer, out buffer);
 
-			var specifity = string.Format("{0}{1}{2}",
-				ids,
-				(classes + attributes),
-				elementNames
-			);
-
-			var result = 0;
-			var success = int.TryParse(specifity, out result);
-
-			if (!success)
-				throw new ApplicationException(string.Format(
-					"Unexpected error calculating specificity for CSS selector '{0}'.", selector));
-
-			return result;
+			var specificity = new CssSpecificity(ids, (classes + attributes + psuedoClasses), (elementNames + psuedoElems));
+			return result + specificity;
 		}
 
 		private static int MatchCountAndStrip(Regex regex, string selector, out string result)
@@ -74,6 +80,107 @@ namespace PreMailer.Net
 			result = regex.Replace(selector, string.Empty);
 
 			return matches.Count;
+		}
+
+		private static Regex BuildPsuedoClassesRegex()
+		{
+			return BuildOrRegex(PsuedoClasses, ":", x => x.Replace("()", @"\(\w+\)"));
+		}
+
+		private static string[] PsuedoClasses
+		{
+			get
+			{
+				// Taken from https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
+				return new[]
+				{
+					"active",
+					"checked",
+					"default",
+					"dir()",
+					"disabled",
+					"empty",
+					"enabled",
+					"first",
+					"first-child",
+					"first-of-type",
+					"fullscreen",
+					"focus",
+					"hover",
+					"indeterminate",
+					"in-range",
+					"invalid",
+					"lang()",
+					"last-child",
+					"last-of-type",
+					"left",
+					"link",
+					"not()",
+					"nth-child()",
+					"nth-last-child()",
+					"nth-last-of-type()",
+					"nth-of-type()",
+					"only-child",
+					"only-of-type",
+					"optional",
+					"out-of-range",
+					"read-only",
+					"read-write",
+					"required",
+					"right",
+					"root",
+					"scope",
+					"target",
+					"valid",
+					"visited"
+				}
+				.Reverse().ToArray(); // NOTE: Reversal is imporant to ensure 'first-line' is processed before 'first'.
+			}
+		}
+
+		private static Regex BuildPsuedoElementsRegex()
+		{
+			return BuildOrRegex(PsuedoElements, "::?");
+		}
+
+		private static string[] PsuedoElements
+		{
+			get
+			{
+				// Taken from: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements
+				return new[]
+				{
+					"after",
+					"before",
+					"first-letter",
+					"first-line",
+					"selection"
+				};
+			}
+		}
+
+		private static Regex BuildOrRegex(string[] items, string prefix, Func<string, string> mutator = null)
+		{
+			var sb = new StringBuilder();
+			sb.Append(prefix);
+			sb.Append("(");
+			for (var i = 0; i < items.Length; i++)
+			{
+				var @class = items[i];
+
+				if (mutator != null)
+				{
+					@class = mutator(@class);
+				}
+
+				sb.Append(@class);
+
+				if (i < (items.Length - 1))
+					sb.Append("|");
+			}
+
+			sb.Append(")");
+			return new Regex(sb.ToString(), RegexOptions.IgnoreCase);
 		}
 	}
 }

--- a/PreMailer.Net/PreMailer.Net/CssSpecificity.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSpecificity.cs
@@ -1,0 +1,53 @@
+﻿namespace PreMailer.Net
+{
+	public class CssSpecificity
+	{
+		public int Ids { get; protected set; }
+
+		/// <summary>
+		/// Classes, attributes and psuedo-classes.
+		/// </summary>
+		public int Classes { get; protected set; }
+
+		/// <summary>
+		/// Elements and psuedo-elements.
+		/// </summary>
+		public int Elements { get; protected set; }
+
+		public static CssSpecificity None
+		{
+			get
+			{
+				return new CssSpecificity(0, 0, 0);
+			}
+		}
+
+		public CssSpecificity(int ids, int classes, int elements)
+		{
+			Ids = ids;
+			Classes = classes;
+			Elements = elements;
+		}
+
+		public int ToInt()
+		{
+			var s = ToString();
+			var result = 0;
+			var success = int.TryParse(s, out result);
+			return result;
+		}
+
+		public override string ToString()
+		{
+			return string.Format("{0}{1}{2}", Ids, Classes, Elements);
+		}
+
+		public static CssSpecificity operator +(CssSpecificity first, CssSpecificity second)
+		{
+			return new CssSpecificity(
+				first.Ids + second.Ids,
+				first.Classes + second.Classes,
+				first.Elements + second.Elements);
+		}
+	}
+}

--- a/PreMailer.Net/PreMailer.Net/PreMailer.Net.csproj
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.Net.csproj
@@ -49,7 +49,9 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="CssParser.cs" />
+    <Compile Include="CssSelector.cs" />
     <Compile Include="CssSelectorParser.cs" />
+    <Compile Include="CssSpecificity.cs" />
     <Compile Include="ICssSelectorParser.cs" />
     <Compile Include="PreMailer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Hey @martinnormark - another thing I noticed on my travels. I had messed up the specificity calc to _add_ the `int` values rather than concat them as a `string`, and then convert to an `int`.

My bad - this is what happens when you write code late :smile: 
