### PR TITLE
Prevent Choking on Pseudo Classes/Elements. Fixes #17

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/CssSelectorParserTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssSelectorParserTests.cs
@@ -5,7 +5,7 @@ namespace PreMailer.Net.Tests
 	[TestClass]
 	public class CssSelectorParserTests
 	{
-		private CssSelectorParser _parser;
+		private ICssSelectorParser _parser;
 
 		[TestInitialize]
 		public void TestInitialize()
@@ -85,14 +85,14 @@ namespace PreMailer.Net.Tests
 		}
 
 		[TestMethod]
-		public void GetSelectorSpecificity_OneIdAndElementInPsuedoElement_Returns101()
+		public void GetSelectorSpecificity_OneIdAndElementInPseudoElement_Returns101()
 		{
 			var result = _parser.GetSelectorSpecificity("#s12:after");
 			Assert.AreEqual(101, result);
 		}
 
 		[TestMethod]
-		public void GetSelectorSpecificity_OneIdAndElementInNotPsuedoClass_Returns101()
+		public void GetSelectorSpecificity_OneIdAndElementInNotPseudoClass_Returns101()
 		{
 			var result = _parser.GetSelectorSpecificity("#s12:not(FOO)");
 			Assert.AreEqual(101, result);
@@ -113,7 +113,7 @@ namespace PreMailer.Net.Tests
 		}
 
 		[TestMethod]
-		public void GetSelectorSpecificity_ElementWithPsuedoClass_Returns11()
+		public void GetSelectorSpecificity_ElementWithPseudoClass_Returns11()
 		{
 			var result = _parser.GetSelectorSpecificity("li:first-child");
 			Assert.AreEqual(11, result);
@@ -124,6 +124,34 @@ namespace PreMailer.Net.Tests
 		{
 			var result = _parser.GetSelectorSpecificity("#id .class element element element element element element element element element element");
 			Assert.AreEqual(1110, result);
+		}
+
+		[TestMethod]
+		public void IsPseudoClass_SelectorWithoutPseudoClass_ReturnsFalse()
+		{
+			var result = _parser.IsPseudoClass("a");
+			Assert.IsFalse(result);
+		}
+
+		[TestMethod]
+		public void IsPseudoClass_SelectorWithPseudoClass_ReturnsTrue()
+		{
+			var result = _parser.IsPseudoClass("a:active");
+			Assert.IsTrue(result);
+		}
+
+		[TestMethod]
+		public void IsPseudoElement_SelectorWithoutPseudoElement_ReturnsFalse()
+		{
+			var result = _parser.IsPseudoElement("p");
+			Assert.IsFalse(result);
+		}
+
+		[TestMethod]
+		public void IsPseudoElement_SelectorWithPseudoElement_ReturnsTrue()
+		{
+			var result = _parser.IsPseudoElement("p:first-line");
+			Assert.IsTrue(result);
 		}
 	}
 }

--- a/PreMailer.Net/PreMailer.Net.Tests/CssSelectorTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssSelectorTests.cs
@@ -6,46 +6,46 @@ namespace PreMailer.Net.Tests
 	public class CssSelectorTests
 	{
 		[TestMethod]
-		public void ContainsNotPsuedoClass_ElementWithPsuedoClass_ReturnsFalse()
+		public void ContainsNotPseudoClass_ElementWithPseudoClass_ReturnsFalse()
 		{
 			var selector = new CssSelector("li:first-child");
-			Assert.IsFalse(selector.HasNotPsuedoClass);
+			Assert.IsFalse(selector.HasNotPseudoClass);
 		}
 		
 		[TestMethod]
-		public void ContainsNotPsuedoClass_ElementWithNotPsuedoClass_ReturnsTrue()
+		public void ContainsNotPseudoClass_ElementWithNotPseudoClass_ReturnsTrue()
 		{
 			var selector = new CssSelector("li:not(.ignored)");
-			Assert.IsTrue(selector.HasNotPsuedoClass);
+			Assert.IsTrue(selector.HasNotPseudoClass);
 		}
 		
 		[TestMethod]
-		public void NotPsuedoClassContent_ElementWithPsuedoClass_ReturnsNull()
+		public void NotPseudoClassContent_ElementWithPseudoClass_ReturnsNull()
 		{
 			var selector = new CssSelector("li:first-child");
-			Assert.IsNull(selector.NotPsuedoClassContent);
+			Assert.IsNull(selector.NotPseudoClassContent);
 		}
 		
 		[TestMethod]
-		public void NotPsuedoClassContent_ElementWithNotPsuedoClass_ReturnsContent()
+		public void NotPseudoClassContent_ElementWithNotPseudoClass_ReturnsContent()
 		{
 			var selector = new CssSelector("li:not(.ignored)");
-			Assert.AreEqual(".ignored", selector.NotPsuedoClassContent);
+			Assert.AreEqual(".ignored", selector.NotPseudoClassContent);
 		}
 		
 		[TestMethod]
-		public void StripNotPsuedoClassContent_ElementWithPsuedoClass_ReturnsOriginalSelector()
+		public void StripNotPseudoClassContent_ElementWithPseudoClass_ReturnsOriginalSelector()
 		{
 			var expected = "li:first-child";
 			var selector = new CssSelector(expected);
-			Assert.AreEqual(expected, selector.StripNotPsuedoClassContent().ToString());
+			Assert.AreEqual(expected, selector.StripNotPseudoClassContent().ToString());
 		}
 		
 		[TestMethod]
-		public void StripNotPsuedoClassContent_ElementWithNotPsuedoClass_ReturnsSelectorWithoutNot()
+		public void StripNotPseudoClassContent_ElementWithNotPseudoClass_ReturnsSelectorWithoutNot()
 		{
 			var selector = new CssSelector("li:not(.ignored)");
-			Assert.AreEqual("li", selector.StripNotPsuedoClassContent().ToString());
+			Assert.AreEqual("li", selector.StripNotPseudoClassContent().ToString());
 		}
 	}
 }

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -62,5 +62,18 @@ namespace PreMailer.Net.Tests
 
 			Assert.IsTrue(premailedOutput.Contains("style=\"width: 42px;\""));
 		}
+
+		[TestMethod]
+		public void MoveCssInline_UnsupportedPseudoSelector_WritesFailedSelectorToComment()
+		{
+			string input = "<html><head><style type=\"text/css\">li:before { width: 42px; }</style></head><body><div><div class=\"target\">test</div></div></body></html>";
+
+			string premailedOutput = sut.MoveCssInline(input);
+
+			Assert.IsTrue(premailedOutput.Contains("<!--"));
+			Assert.IsTrue(premailedOutput.Contains("PreMailer.Net was unable to handle the following selector(s):"));
+			Assert.IsTrue(premailedOutput.Contains("* li:before"));
+			Assert.IsTrue(premailedOutput.Contains("-->"));
+		}
 	}
 }

--- a/PreMailer.Net/PreMailer.Net/CssSelector.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSelector.cs
@@ -8,7 +8,7 @@ namespace PreMailer.Net
 
 		public string Selector { get; protected set; }
 
-		public bool HasNotPsuedoClass
+		public bool HasNotPseudoClass
 		{
 			get
 			{
@@ -16,7 +16,7 @@ namespace PreMailer.Net
 			}
 		}
 		
-		public string NotPsuedoClassContent
+		public string NotPseudoClassContent
 		{
 			get
 			{
@@ -30,7 +30,7 @@ namespace PreMailer.Net
 			Selector = selector;
 		}
 
-		public CssSelector StripNotPsuedoClassContent()
+		public CssSelector StripNotPseudoClassContent()
 		{
 			var stripped = NotMatcher.Replace(Selector, string.Empty);
 			return new CssSelector(stripped);

--- a/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
@@ -10,18 +10,18 @@ namespace PreMailer.Net
 		private readonly Regex _idMatcher;
 		private readonly Regex _attribMatcher;
 		private readonly Regex _classMatcher;
-		private readonly Regex _psuedoClassMatcher;
+		private readonly Regex _pseudoClassMatcher;
 		private readonly Regex _elemMatcher;
-		private readonly Regex _psuedoElemMatcher;
+		private readonly Regex _pseudoElemMatcher;
 
 		public CssSelectorParser()
 		{
 			_idMatcher = new Regex(@"#([\w]+)", RegexOptions.Compiled & RegexOptions.IgnoreCase);
 			_attribMatcher = new Regex(@"\[[\w=]+\]", RegexOptions.Compiled & RegexOptions.IgnoreCase);
 			_classMatcher = new Regex(@"\.([\w]+)", RegexOptions.Compiled & RegexOptions.IgnoreCase);
-			_psuedoClassMatcher = BuildPsuedoClassesRegex();
+			_pseudoClassMatcher = BuildPseudoClassesRegex();
 			_elemMatcher = new Regex(@"[a-zA-Z]+", RegexOptions.Compiled & RegexOptions.IgnoreCase);
-			_psuedoElemMatcher = BuildPsuedoElementsRegex();
+			_pseudoElemMatcher = BuildPseudoElementsRegex();
 		}
 
 		/// <summary>
@@ -55,22 +55,32 @@ namespace PreMailer.Net
 			var cssSelector = new CssSelector(selector);
 
 			var result = CssSpecificity.None;
-			if (cssSelector.HasNotPsuedoClass)
+			if (cssSelector.HasNotPseudoClass)
 			{
-				result += CalculateSpecificity(cssSelector.NotPsuedoClassContent);
+				result += CalculateSpecificity(cssSelector.NotPseudoClassContent);
 			}
 
-			var buffer = cssSelector.StripNotPsuedoClassContent().ToString();
+			var buffer = cssSelector.StripNotPseudoClassContent().ToString();
 
 			var ids = MatchCountAndStrip(_idMatcher, buffer, out buffer);
 			var attributes = MatchCountAndStrip(_attribMatcher, buffer, out buffer);
 			var classes = MatchCountAndStrip(_classMatcher, buffer, out buffer);
-			var psuedoClasses = MatchCountAndStrip(_psuedoClassMatcher, buffer, out buffer);
+			var pseudoClasses = MatchCountAndStrip(_pseudoClassMatcher, buffer, out buffer);
 			var elementNames = MatchCountAndStrip(_elemMatcher, buffer, out buffer);
-			var psuedoElems = MatchCountAndStrip(_psuedoElemMatcher, buffer, out buffer);
+			var pseudoElements = MatchCountAndStrip(_pseudoElemMatcher, buffer, out buffer);
 
-			var specificity = new CssSpecificity(ids, (classes + attributes + psuedoClasses), (elementNames + psuedoElems));
+			var specificity = new CssSpecificity(ids, (classes + attributes + pseudoClasses), (elementNames + pseudoElements));
 			return result + specificity;
+		}
+
+		public bool IsPseudoClass(string selector)
+		{
+			return _pseudoClassMatcher.IsMatch(selector);
+		}
+
+		public bool IsPseudoElement(string selector)
+		{
+			return _pseudoElemMatcher.IsMatch(selector);
 		}
 
 		private static int MatchCountAndStrip(Regex regex, string selector, out string result)
@@ -82,12 +92,12 @@ namespace PreMailer.Net
 			return matches.Count;
 		}
 
-		private static Regex BuildPsuedoClassesRegex()
+		private static Regex BuildPseudoClassesRegex()
 		{
-			return BuildOrRegex(PsuedoClasses, ":", x => x.Replace("()", @"\(\w+\)"));
+			return BuildOrRegex(PseudoClasses, ":", x => x.Replace("()", @"\(\w+\)"));
 		}
 
-		private static string[] PsuedoClasses
+		private static string[] PseudoClasses
 		{
 			get
 			{
@@ -138,12 +148,12 @@ namespace PreMailer.Net
 			}
 		}
 
-		private static Regex BuildPsuedoElementsRegex()
+		private static Regex BuildPseudoElementsRegex()
 		{
-			return BuildOrRegex(PsuedoElements, "::?");
+			return BuildOrRegex(PseudoElements, "::?");
 		}
 
-		private static string[] PsuedoElements
+		private static string[] PseudoElements
 		{
 			get
 			{

--- a/PreMailer.Net/PreMailer.Net/CssSpecificity.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSpecificity.cs
@@ -5,12 +5,12 @@
 		public int Ids { get; protected set; }
 
 		/// <summary>
-		/// Classes, attributes and psuedo-classes.
+		/// Classes, attributes and pseudo-classes.
 		/// </summary>
 		public int Classes { get; protected set; }
 
 		/// <summary>
-		/// Elements and psuedo-elements.
+		/// Elements and pseudo-elements.
 		/// </summary>
 		public int Elements { get; protected set; }
 

--- a/PreMailer.Net/PreMailer.Net/ICssSelectorParser.cs
+++ b/PreMailer.Net/PreMailer.Net/ICssSelectorParser.cs
@@ -1,7 +1,9 @@
 ﻿namespace PreMailer.Net
 {
-    public interface ICssSelectorParser
-    {
-        int GetSelectorSpecificity(string selector);
-    }
+	public interface ICssSelectorParser
+	{
+		int GetSelectorSpecificity(string selector);
+		bool IsPseudoElement(string selector);
+		bool IsPseudoClass(string selector);
+	}
 }


### PR DESCRIPTION
Rather than let the `NotImplementedException` bubble from CsQuery [here](https://github.com/jamietre/CsQuery/blob/30b56cf832ac3c4d09a30fe6a8164df819b57782/source/CsQuery/Engine/SelectorParser.cs#L135), we strip out pseudo classes/elements before processing. We also add a HTML comment to the output to say we've done so to (hopefully) avoid confusion.

Also realised I've been writing 'psuedo' everywhere. So corrected the typos too. <facepalm/>
