### PR TITLE
Ensure 'ignoreElements' Doesn't Hose Style Tags. Fixes #25.

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -75,5 +75,15 @@ namespace PreMailer.Net.Tests
 			Assert.IsTrue(premailedOutput.Contains("* li:before"));
 			Assert.IsTrue(premailedOutput.Contains("-->"));
 		}
+
+		[TestMethod]
+		public void MoveCssInline_KeepStyleElementsIgnoreElementsMatchesStyleElement_DoesntRemoveScriptTag()
+		{
+			string input = "<html><head><style id=\"ignore\" type=\"text/css\">li:before { width: 42px; }</style></head><body><div class=\"target\">test</div></body></html>";
+
+			string premailedOutput = sut.MoveCssInline(input, removeStyleElements: false, ignoreElements: "#ignore");
+
+			Assert.IsTrue(premailedOutput.Contains("<style id=\"ignore\" type=\"text/css\">"));
+		}
 	}
 }

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -72,22 +72,11 @@ namespace PreMailer.Net
 
 		internal static CQ NodesWithStyles(this CQ document, string ignoreElements = null)
 		{
-			if (!string.IsNullOrWhiteSpace(ignoreElements))
-			{
-				// For some reason, the following code was not working - no idea why not. Tried several variations.
-				// document.Remove(ignoreElements);
-				var stripElements = document.Find(ignoreElements);
-				foreach (var el in stripElements)
-				{
-					el.Remove();
-				}
-			}
-
 			// TODO: Add Source to Read CSS from LINK tags etc.
 			// All we need to do here is update the selector in 'document.Find(...)' and then add
 			// something that implements ICssSource to handle that type of link..
 			// e.g. new LinkTagCssSource(node, baseUrl: "...");
-			var elements = document.Find("style");
+			var elements = document.Find("style").Not(ignoreElements);
 			return elements;
 		}
 


### PR DESCRIPTION
'ignoreElements was stripping out the elements to be processed by removing them from the document. This is obviously no good - stemmed from my lack of knowledge of CsQuery. CS.Remove() will always remove from the parent Document, regardless of the instance being executed against. CS.Find().Not() is what we wanted.
