### PR TITLE
Null object reference exception for styles with media queries

### DIFF
--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -180,20 +180,21 @@ namespace PreMailer.Net
 			var result = new Dictionary<IDomObject, List<StyleClass>>();
 
 			foreach (var style in styles)
-			{
-				var sortedStyles = style.Value.OrderBy(x => _cssSelectorParser.GetSelectorSpecificity(x.Name)).ToList();
+                if (style.Key.Attributes != null)
+                {
+                    var sortedStyles = style.Value.OrderBy(x => _cssSelectorParser.GetSelectorSpecificity(x.Name)).ToList();
 
-				if (String.IsNullOrWhiteSpace(style.Key.Attributes["style"]))
-				{
-					style.Key.SetAttribute("style", String.Empty);
-				}
-				else // Ensure that existing inline styles always win.
-				{
-					sortedStyles.Add(_cssParser.ParseStyleClass("inline", style.Key.Attributes["style"]));
-				}
+                    if (String.IsNullOrWhiteSpace(style.Key.Attributes["style"]))
+                    {
+                        style.Key.SetAttribute("style", String.Empty);
+                    }
+                    else // Ensure that existing inline styles always win.
+                    {
+                        sortedStyles.Add(_cssParser.ParseStyleClass("inline", style.Key.Attributes["style"]));
+                    }
 
-				result[style.Key] = sortedStyles;
-			}
+                    result[style.Key] = sortedStyles;
+                }
 
 			return result;
 		}


### PR DESCRIPTION
Hi,

I tried Premailer with the new Ink framework from Zurb and noticed that Premailer has problems with media queries found inside ink.css. I'm not sure if this is the correct fix, but at least it enables in-lining without exception.
