### PR TITLE
Don't force lowercase on rules and values

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/CssAttributeTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssAttributeTests.cs
@@ -15,12 +15,21 @@ namespace PreMailer.Net.Tests
         }
 
         [TestMethod]
-        public void MixedCaseRule_ReturnsLoweredAttribute()
+        public void MixedCaseRuleValue_RetainsCasing()
         {
             var attribute = CssAttribute.FromRule(" color: rED");
 
             Assert.AreEqual("color", attribute.Style);
-            Assert.AreEqual("red", attribute.Value);
+            Assert.AreEqual("rED", attribute.Value);
+        }
+
+        [TestMethod]
+        public void MixedCaseRule_RetainsCasing()
+        {
+            var attribute = CssAttribute.FromRule("Margin-bottom: 10px");
+
+            Assert.AreEqual("Margin-bottom", attribute.Style);
+            Assert.AreEqual("10px", attribute.Value);
         }
 
         [TestMethod]
@@ -46,7 +55,7 @@ namespace PreMailer.Net.Tests
         {
             var attribute = CssAttribute.FromRule("background: url('http://my.web.site.com/Content/email/content.png') repeat-y");
 
-            Assert.AreEqual("url('http://my.web.site.com/content/email/content.png') repeat-y", attribute.Value);
+            Assert.AreEqual("url('http://my.web.site.com/Content/email/content.png') repeat-y", attribute.Value);
         }
     }
 }

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -132,7 +132,7 @@ namespace PreMailer.Net.Tests
 
 			var premailedOutput = PreMailer.MoveCssInline(input);
 
-			Assert.IsTrue(premailedOutput.Html.Contains("<div style=\"background: url('http://my.web.site.com/content/email/content.png') repeat-y\"></div>"));
+			Assert.IsTrue(premailedOutput.Html.Contains("<div style=\"background: url('http://my.web.site.com/Content/email/content.png') repeat-y\"></div>"));
 		}
 
 		public void MoveCssInline_SupportedMediaAttribute_InlinesAsNormal()

--- a/PreMailer.Net/PreMailer.Net.Tests/StyleClassTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/StyleClassTests.cs
@@ -102,5 +102,21 @@ namespace PreMailer.Net.Tests
             Assert.IsTrue(target.Attributes.ContainsKey("height"));
             Assert.AreEqual("100%", target.Attributes["height"].Value);
         }
+
+        [TestMethod]
+        public void Merge_ShouldOverrideExistingEntriesIfSpecifiedIgnoringCasing()
+        {
+            var target = new StyleClass();
+            var donator = new StyleClass();
+
+            target.Attributes["color"] = CssAttribute.FromRule("color: red");
+            target.Attributes["HEight"] = CssAttribute.FromRule("height: 50%");
+            donator.Attributes["height"] = CssAttribute.FromRule("height: 100%");
+
+            target.Merge(donator, true);
+
+            Assert.IsTrue(target.Attributes.ContainsKey("height"));
+            Assert.AreEqual("100%", target.Attributes["height"].Value);
+        }
     }
 }

--- a/PreMailer.Net/PreMailer.Net/CssAttribute.cs
+++ b/PreMailer.Net/PreMailer.Net/CssAttribute.cs
@@ -16,16 +16,16 @@ namespace PreMailer.Net {
 
             if (parts.Length == 1) return null;
 
-            var value = parts[1].Trim().ToLower();
+            var value = parts[1].Trim();
             var important = false;
 
-            if(value.Contains("!important")) {
+            if(value.IndexOf("!important", StringComparison.CurrentCultureIgnoreCase) != -1) {
                 important = true;
                 value = value.Replace(" !important", "");
             }
 
             return new CssAttribute {
-                Style = parts[0].Trim().ToLower(),
+                Style = parts[0].Trim(),
                 Value = value,
                 Important = important
             };

--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -84,12 +84,12 @@ namespace PreMailer.Net {
             sc.Name = styleName;
 
             //string[] atrs = style.Split(';');
-						string[] atrs = CleanUp(style).Split(';');
+			string[] atrs = CleanUp(style).Split(';');
 
             foreach (string a in atrs) {
-								var attribute = CssAttribute.FromRule(a);
+				var attribute = CssAttribute.FromRule(a);
 
-								if (attribute != null) sc.Attributes[attribute.Style] = attribute;
+				if (attribute != null) sc.Attributes[attribute.Style] = attribute;
             }
         }
 
@@ -98,7 +98,7 @@ namespace PreMailer.Net {
         private string CleanUp(string s)
         {
             string temp = s;
-						const string cssCommentRegex = @"(?:/\*(.|[\r\n])*?\*/)|(?:(?<!url\s*\([^)]*)//.*)";
+			const string cssCommentRegex = @"(?:/\*(.|[\r\n])*?\*/)|(?:(?<!url\s*\([^)]*)//.*)";
             const string unsupportedAtRuleRegex = "(?:@charset [^;]*;)|(?:@(page|font-face)[^{]*{[^}]*})";
 
             temp = Regex.Replace(temp, cssCommentRegex, "");

--- a/PreMailer.Net/PreMailer.Net/StyleClass.cs
+++ b/PreMailer.Net/PreMailer.Net/StyleClass.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace PreMailer.Net {
@@ -6,8 +7,9 @@ namespace PreMailer.Net {
         /// <summary>
         /// Initializes a new instance of the <see cref="StyleClass"/> class.
         /// </summary>
-        public StyleClass() {
-            Attributes = new Dictionary<string, CssAttribute>();
+        public StyleClass() 
+        {
+            Attributes = new Dictionary<string, CssAttribute>(StringComparer.CurrentCultureIgnoreCase);
         }
 
         /// <summary>


### PR DESCRIPTION
There's a couple of reason for this, firstly depending on webservers, urls may be case sensitive and font names should be retained in original casing. Secondly, Outlook.com strips lowercased margin properties, but leaves capitalised properties. 
