### PR TITLE
Handle import statements in input css

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/CssParserTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssParserTests.cs
@@ -82,10 +82,23 @@ namespace PreMailer.Net.Tests
             Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
 	    }
 
+
         [TestMethod]
-        public void AddStylesheet_ContainsImportStatementWithoutSpace_ShouldStripOutImportStatement()
+        public void AddStylesheet_ContainsImportStatementTest_ShouldStripOutImportStatement()
         {
-            var stylesheet = "@import url(http://google.com/stylesheet);div { width : 600px; }";
+            var stylesheet = "@import 'stylesheet.css'; div { width : 600px; }";
+            var parser = new CssParser();
+            parser.AddStyleSheet(stylesheet);
+            Assert.AreEqual(1, parser.Styles.Count);
+
+            Assert.IsTrue(parser.Styles.ContainsKey("div"));
+            Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
+        }
+
+        [TestMethod]
+        public void AddStylesheet_ContainsMinifiedImportStatement_ShouldStripOutImportStatement()
+        {
+            var stylesheet = "@import url(http://google.com/stylesheet);div{width:600px;}";
             var parser = new CssParser();
             parser.AddStyleSheet(stylesheet);
             Assert.AreEqual(1, parser.Styles.Count);

--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -99,7 +99,7 @@ namespace PreMailer.Net {
         {
             string temp = s;
 			const string cssCommentRegex = @"(?:/\*(.|[\r\n])*?\*/)|(?:(?<!url\s*\([^)]*)//.*)";
-            const string unsupportedAtRuleRegex = @"(?:@charset [^;]*;)|(?:@(page|font-face)[^{]*{[^}]*})|@import url\((.+?)\).*?;";
+            const string unsupportedAtRuleRegex = @"(?:@charset [^;]*;)|(?:@(page|font-face)[^{]*{[^}]*})|@import.+?;";
 
             temp = Regex.Replace(temp, cssCommentRegex, "");
             temp = Regex.Replace(temp, unsupportedAtRuleRegex, "", RegexOptions.IgnoreCase);


### PR DESCRIPTION
Currently, if you have import statements e.g. to support webfonts, they are interpreted as being part of the first selector.  This pull request resolves this by ignoring import statements.

Let me know what you think.
