### PR TITLE
Add analytics tags using PreMailer

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -229,15 +229,26 @@ namespace PreMailer.Net.Tests
 			Assert.IsTrue(premailedOutput.Html.Contains("<div style=\"width: 42px\">"));
 		}
 
-        [TestMethod]
-        public void AddAnalyticsTags_AddsTags()
-        {
-            const string input = @"<div><a href=""blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1"">Extra Stuff</a></div>";
-            const string expected = @"<html><head></head><body><div><a href=""blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1&utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Extra Stuff</a></div></body></html>";
-            var premailedOutput = new PreMailer(input)
-                .AddAnalyticsTags("source", "medium", "campaign", "content")
-                .Render();
-            Assert.IsTrue(expected == premailedOutput.Html);
-        }
-    }
+		[TestMethod]
+		public void AddAnalyticsTags_AddsTags()
+		{
+			const string input = @"<div><a href=""blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1"">Extra Stuff</a></div>";
+			const string expected = @"<html><head></head><body><div><a href=""blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1&utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Extra Stuff</a></div></body></html>";
+			var premailedOutput = new PreMailer(input)
+				.AddAnalyticsTags("source", "medium", "campaign", "content")
+				.Render();
+			Assert.IsTrue(expected == premailedOutput.Html);
+		}
+
+		[TestMethod]
+		public void AddAnalyticsTags_AddsTagsAndExcludesDomain()
+		{
+			const string input = @"<div><a href=""http://www.blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""https://www.nomatch.com/someurl?extra=1"">Extra Stuff</a></div>";
+			const string expected = @"<html><head></head><body><div><a href=""http://www.blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""https://www.nomatch.com/someurl?extra=1"">Extra Stuff</a></div></body></html>";
+			var premailedOutput = new PreMailer(input)
+				.AddAnalyticsTags("source", "medium", "campaign", "content", "www.Blah.com")
+				.Render();
+			Assert.IsTrue(expected == premailedOutput.Html);
+		}
+	}
 }

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace PreMailer.Net.Tests
 {
@@ -227,5 +228,16 @@ namespace PreMailer.Net.Tests
 
 			Assert.IsTrue(premailedOutput.Html.Contains("<div style=\"width: 42px\">"));
 		}
-	}
+
+        [TestMethod]
+        public void AddAnalyticsTags_AddsTags()
+        {
+            const string input = @"<div><a href=""blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1"">Extra Stuff</a></div>";
+            const string expected = @"<html><head></head><body><div><a href=""blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1&utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Extra Stuff</a></div></body></html>";
+            var premailedOutput = new PreMailer(input)
+                .AddAnalyticsTags("source", "medium", "campaign", "content")
+                .Render();
+            Assert.IsTrue(expected == premailedOutput.Html);
+        }
+    }
 }

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -230,13 +230,24 @@ namespace PreMailer.Net.Tests
 		}
 
 		[TestMethod]
+		public void MoveCssInline_StripsComments()
+		{
+			string input = "<html><head></head><body><!--This should be removed--></body></html>";
+			string expected = "<html><head></head><body></body></html>";
+
+			var premailedOutput = PreMailer.MoveCssInline(input, removeComments: true);
+
+			Assert.IsTrue(expected == premailedOutput.Html);
+		}
+
+		[TestMethod]
 		public void AddAnalyticsTags_AddsTags()
 		{
 			const string input = @"<div><a href=""blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1"">Extra Stuff</a></div>";
 			const string expected = @"<html><head></head><body><div><a href=""blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1&utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Extra Stuff</a></div></body></html>";
 			var premailedOutput = new PreMailer(input)
 				.AddAnalyticsTags("source", "medium", "campaign", "content")
-				.Render();
+				.MoveCssInline();
 			Assert.IsTrue(expected == premailedOutput.Html);
 		}
 
@@ -247,7 +258,7 @@ namespace PreMailer.Net.Tests
 			const string expected = @"<html><head></head><body><div><a href=""http://www.blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""https://www.nomatch.com/someurl?extra=1"">Extra Stuff</a></div></body></html>";
 			var premailedOutput = new PreMailer(input)
 				.AddAnalyticsTags("source", "medium", "campaign", "content", "www.Blah.com")
-				.Render();
+				.MoveCssInline();
 			Assert.IsTrue(expected == premailedOutput.Html);
 		}
 	}

--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -96,7 +96,7 @@ namespace PreMailer.Net
 
             //string[] atrs = style.Split(';');
             //string[] atrs = CleanUp(style).Split(';');
-            string[] atrs = Regex.Split(CleanUp(style), @"(;)(?=(?:[^""']|[""|'][^""']*"")*$)", RegexOptions.Multiline | RegexOptions.Compiled);
+            string[] atrs = FillStyleClassRegex.Split(CleanUp(style));
 
             foreach (string a in atrs)
             {
@@ -106,16 +106,14 @@ namespace PreMailer.Net
             }
         }
 
-
+		private static Regex FillStyleClassRegex = new Regex(@"(;)(?=(?:[^""']|[""|'][^""']*"")*$)", RegexOptions.Multiline | RegexOptions.Compiled);
+	    private static Regex CssCommentRegex = new Regex(@"(?:/\*(.|[\r\n])*?\*/)|(?:(?<!url\s*\([^)]*)//.*)", RegexOptions.Compiled);
+		private static Regex UnsupportedAtRuleRegex = new Regex(@"(?:@charset [^;]*;)|(?:@(page|font-face)[^{]*{[^}]*})|@import.+?;", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private string CleanUp(string s)
         {
-            string temp = s;
-            const string cssCommentRegex = @"(?:/\*(.|[\r\n])*?\*/)|(?:(?<!url\s*\([^)]*)//.*)";
-            const string unsupportedAtRuleRegex = @"(?:@charset [^;]*;)|(?:@(page|font-face)[^{]*{[^}]*})|@import.+?;";
-
-            temp = Regex.Replace(temp, cssCommentRegex, "");
-            temp = Regex.Replace(temp, unsupportedAtRuleRegex, "", RegexOptions.IgnoreCase);
+            string temp = CssCommentRegex.Replace(s, "");
+            temp = UnsupportedAtRuleRegex.Replace(temp, "");
             temp = CleanupMediaQueries(temp);
             temp = temp.Replace("\r", "").Replace("\n", "");
 
@@ -123,17 +121,13 @@ namespace PreMailer.Net
         }
 
         public static Regex SupportedMediaQueriesRegex = new Regex(@"^(?:\s*(?:only\s+)?(?:screen|projection|all),\s*)*(?:(?:only\s+)?(?:screen|projection|all))$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+		private static Regex MediaQueryRegex = new Regex(@"@media\s*(?<query>[^{]*){(?<styles>(?>[^{}]+|{(?<DEPTH>)|}(?<-DEPTH>))*(?(DEPTH)(?!)))}", RegexOptions.Compiled);
 
         private string CleanupMediaQueries(string s)
         {
             string temp = s;
-            const string mediaQueryRegex = @"@media\s*(?<query>[^{]*){(?<styles>(?>[^{}]+|{(?<DEPTH>)|}(?<-DEPTH>))*(?(DEPTH)(?!)))}";
 
-            temp = Regex.Replace(temp, mediaQueryRegex, m =>
-            {
-                return SupportedMediaQueriesRegex.IsMatch(m.Groups["query"].Value.Trim()) ?
-                    m.Groups["styles"].Value.Trim() : string.Empty;
-            });
+            temp = MediaQueryRegex.Replace(temp, m => SupportedMediaQueriesRegex.IsMatch(m.Groups["query"].Value.Trim()) ? m.Groups["styles"].Value.Trim() : string.Empty);
 
             return temp;
         }

--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -122,7 +122,7 @@ namespace PreMailer.Net
             return temp;
         }
 
-        public static Regex SupportedMediaQueriesRegex = new Regex(@"^(?:\s*(?:only\s+)?(?:screen|projection|all),\s*)*(?:(?:only\s+)?(?:screen|projection|all))$", RegexOptions.IgnoreCase);
+        public static Regex SupportedMediaQueriesRegex = new Regex(@"^(?:\s*(?:only\s+)?(?:screen|projection|all),\s*)*(?:(?:only\s+)?(?:screen|projection|all))$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private string CleanupMediaQueries(string s)
         {

--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -96,7 +96,7 @@ namespace PreMailer.Net
 
             //string[] atrs = style.Split(';');
             //string[] atrs = CleanUp(style).Split(';');
-            string[] atrs = FillStyleClassRegex.Split(CleanUp(style));
+            string[] atrs = Regex.Split(CleanUp(style), @"(;)(?=(?:[^""']|[""|'][^""']*"")*$)", RegexOptions.Multiline | RegexOptions.Compiled);
 
             foreach (string a in atrs)
             {
@@ -106,14 +106,16 @@ namespace PreMailer.Net
             }
         }
 
-		private static Regex FillStyleClassRegex = new Regex(@"(;)(?=(?:[^""']|[""|'][^""']*"")*$)", RegexOptions.Multiline | RegexOptions.Compiled);
-	    private static Regex CssCommentRegex = new Regex(@"(?:/\*(.|[\r\n])*?\*/)|(?:(?<!url\s*\([^)]*)//.*)", RegexOptions.Compiled);
-		private static Regex UnsupportedAtRuleRegex = new Regex(@"(?:@charset [^;]*;)|(?:@(page|font-face)[^{]*{[^}]*})|@import.+?;", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
 
         private string CleanUp(string s)
         {
-            string temp = CssCommentRegex.Replace(s, "");
-            temp = UnsupportedAtRuleRegex.Replace(temp, "");
+            string temp = s;
+            const string cssCommentRegex = @"(?:/\*(.|[\r\n])*?\*/)|(?:(?<!url\s*\([^)]*)//.*)";
+            const string unsupportedAtRuleRegex = @"(?:@charset [^;]*;)|(?:@(page|font-face)[^{]*{[^}]*})|@import.+?;";
+
+            temp = Regex.Replace(temp, cssCommentRegex, "");
+            temp = Regex.Replace(temp, unsupportedAtRuleRegex, "", RegexOptions.IgnoreCase);
             temp = CleanupMediaQueries(temp);
             temp = temp.Replace("\r", "").Replace("\n", "");
 
@@ -121,13 +123,17 @@ namespace PreMailer.Net
         }
 
         public static Regex SupportedMediaQueriesRegex = new Regex(@"^(?:\s*(?:only\s+)?(?:screen|projection|all),\s*)*(?:(?:only\s+)?(?:screen|projection|all))$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-		private static Regex MediaQueryRegex = new Regex(@"@media\s*(?<query>[^{]*){(?<styles>(?>[^{}]+|{(?<DEPTH>)|}(?<-DEPTH>))*(?(DEPTH)(?!)))}", RegexOptions.Compiled);
 
         private string CleanupMediaQueries(string s)
         {
             string temp = s;
+            const string mediaQueryRegex = @"@media\s*(?<query>[^{]*){(?<styles>(?>[^{}]+|{(?<DEPTH>)|}(?<-DEPTH>))*(?(DEPTH)(?!)))}";
 
-            temp = MediaQueryRegex.Replace(temp, m => SupportedMediaQueriesRegex.IsMatch(m.Groups["query"].Value.Trim()) ? m.Groups["styles"].Value.Trim() : string.Empty);
+            temp = Regex.Replace(temp, mediaQueryRegex, m =>
+            {
+                return SupportedMediaQueriesRegex.IsMatch(m.Groups["query"].Value.Trim()) ?
+                    m.Groups["styles"].Value.Trim() : string.Empty;
+            });
 
             return temp;
         }

--- a/PreMailer.Net/PreMailer.Net/CssSelector.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSelector.cs
@@ -4,7 +4,7 @@ namespace PreMailer.Net
 {
 	public class CssSelector
 	{
-		protected static Regex NotMatcher = new Regex(@":not\((.+)\)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+		protected static Regex NotMatcher = new Regex(@":not\((.+)\)", RegexOptions.IgnoreCase);
 
 		public string Selector { get; protected set; }
 

--- a/PreMailer.Net/PreMailer.Net/CssSelector.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSelector.cs
@@ -4,7 +4,7 @@ namespace PreMailer.Net
 {
 	public class CssSelector
 	{
-		protected static Regex NotMatcher = new Regex(@":not\((.+)\)", RegexOptions.IgnoreCase & RegexOptions.Compiled);
+		protected static Regex NotMatcher = new Regex(@":not\((.+)\)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
 		public string Selector { get; protected set; }
 

--- a/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
@@ -184,7 +184,7 @@ namespace PreMailer.Net
 
         private static Regex BuildRegex(string pattern)
         {
-            return new Regex(pattern, RegexOptions.Compiled & RegexOptions.IgnoreCase);
+            return new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
         }
 
         private static Regex BuildOrRegex(string[] items, string prefix, Func<string, string> mutator = null)
@@ -208,7 +208,7 @@ namespace PreMailer.Net
             }
 
             sb.Append(")");
-            return new Regex(sb.ToString(), RegexOptions.IgnoreCase & RegexOptions.Compiled);
+            return new Regex(sb.ToString(), RegexOptions.IgnoreCase | RegexOptions.Compiled);
         }
     }
 }

--- a/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
@@ -184,7 +184,7 @@ namespace PreMailer.Net
 
         private static Regex BuildRegex(string pattern)
         {
-            return new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            return new Regex(pattern, RegexOptions.IgnoreCase);
         }
 
         private static Regex BuildOrRegex(string[] items, string prefix, Func<string, string> mutator = null)
@@ -208,7 +208,7 @@ namespace PreMailer.Net
             }
 
             sb.Append(")");
-            return new Regex(sb.ToString(), RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            return new Regex(sb.ToString(), RegexOptions.IgnoreCase);
         }
     }
 }

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -46,27 +46,26 @@ namespace PreMailer.Net
 		        .Render();
 		}
 
-        /// <summary>
-        /// Renders the result and returns it
-        /// </summary>
-        /// <returns>Returns the html and warnings for the resulting html.</returns>
-        public InlineResult Render()
-	    {
-            var html = _document.Render();
-            return new InlineResult(html, _warnings);
-        }
+		/// <summary>
+		/// Renders the result and returns it
+		/// </summary>
+		/// <returns>Returns the html and warnings for the resulting html.</returns>
+		public InlineResult Render()
+		{
+			var html = _document.Render();
+			return new InlineResult(html, _warnings);
+		}
 
-	    /// <summary>
-	    /// Renders the result and returns it
-	    /// </summary>
-	    /// <param name="options">DOM rendering options</param>
-	    /// <returns>Returns the html and warnings for the resulting html.</returns>
-	    public InlineResult Render(
-            DomRenderingOptions options)
-        {
-            var html = _document.Render(options);
-            return new InlineResult(html, _warnings);
-        }
+		/// <summary>
+		/// Renders the result and returns it
+		/// </summary>
+		/// <param name="options">DOM rendering options</param>
+		/// <returns>Returns the html and warnings for the resulting html.</returns>
+		public InlineResult Render(DomRenderingOptions options)
+		{
+			var html = _document.Render(options);
+			return new InlineResult(html, _warnings);
+		}
 
 		/// <summary>
 		/// In-lines the CSS for the current HTML
@@ -74,15 +73,15 @@ namespace PreMailer.Net
 		/// <param name="removeStyleElements">If set to <c>true</c> the style elements are removed.</param>
 		/// <param name="ignoreElements">CSS selector for STYLE elements to ignore (e.g. mobile-specific styles etc.)</param>
 		/// <param name="css">A string containing a style-sheet for inlining.</param>
-        /// <param name="stripIdAndClassAttributes">True to strip ID and class attributes</param>
-        /// <returns>Reference to the instance so you can chain calls.</returns>
+		/// <param name="stripIdAndClassAttributes">True to strip ID and class attributes</param>
+		/// <returns>Reference to the instance so you can chain calls.</returns>
 		public PreMailer MoveCssInline(bool removeStyleElements = false, string ignoreElements = null, string css = null, bool stripIdAndClassAttributes = false)
 		{
-            // Store the variables used for inlining the CSS
-            _removeStyleElements = removeStyleElements;
-            _stripIdAndClassAttributes = stripIdAndClassAttributes;
-            _ignoreElements = ignoreElements;
-            _css = css;
+			// Store the variables used for inlining the CSS
+			_removeStyleElements = removeStyleElements;
+			_stripIdAndClassAttributes = stripIdAndClassAttributes;
+			_ignoreElements = ignoreElements;
+			_css = css;
 
 			// Gather all of the CSS that we can work with.
 			var cssSourceNodes = CssSourceNodes();
@@ -98,35 +97,51 @@ namespace PreMailer.Net
 			var elementsWithStyles = FindElementsWithStyles(validSelectors);
 			var mergedStyles = MergeStyleClasses(elementsWithStyles);
 
-            StyleClassApplier.ApplyAllStyles(mergedStyles);
+			StyleClassApplier.ApplyAllStyles(mergedStyles);
 
 			if (_stripIdAndClassAttributes)
 				StripElementAttributes("id", "class");
 
-            return this;
+			return this;
 		}
 
-	    /// <summary>
-	    /// Function to add Google analytics tracking tags to the HTML document
-	    /// </summary>
-	    /// <param name="source">Source tracking tag</param>
-	    /// <param name="medium">Medium tracking tag</param>
-	    /// <param name="campaign">Campaign tracking tag</param>
-	    /// <param name="content">Content tracking tag</param>
-        /// <returns>Reference to the instance so you can chain calls.</returns>
-        public PreMailer AddAnalyticsTags(
-            string source,
-            string medium,
-            string campaign,
-            string content)
-        {
-            var tracking = "utm_source=" + source + "&utm_medium=" + medium + "&utm_campaign=" + campaign + "&utm_content=" + content;
-            foreach (var tag in _document["a[href]"]) {
-                var href = tag.Attributes["href"];
-                tag.SetAttribute("href", href + (href.IndexOf("?", StringComparison.Ordinal) >= 0 ? "&" : "?") + tracking);
-            }
-	        return this;
-        }
+		/// <summary>
+		/// Function to add Google analytics tracking tags to the HTML document
+		/// </summary>
+		/// <param name="source">Source tracking tag</param>
+		/// <param name="medium">Medium tracking tag</param>
+		/// <param name="campaign">Campaign tracking tag</param>
+		/// <param name="content">Content tracking tag</param>
+		/// <param name="domain">Optional domain check; if it does not match the URL will be skipped</param>
+		/// <returns>Reference to the instance so you can chain calls.</returns>
+		public PreMailer AddAnalyticsTags(string source, string medium, string campaign, string content, string domain = null)
+		{
+			var tracking = "utm_source=" + source + "&utm_medium=" + medium + "&utm_campaign=" + campaign + "&utm_content=" + content;
+			foreach (var tag in _document["a[href]"])
+			{
+				var href = tag.Attributes["href"];
+				if (domain == null || DomainMatch(domain, href))
+				{
+					tag.SetAttribute("href", href + (href.IndexOf("?", StringComparison.Ordinal) >= 0 ? "&" : "?") + tracking);
+				}
+			}
+			return this;
+		}
+
+		/// <summary>
+		/// Function to check if the domain in a URL matches
+		/// </summary>
+		/// <param name="domain">Domain to check</param>
+		/// <param name="url">URL to parse</param>
+		/// <returns>True if the domain matches, false if not</returns>
+		private bool DomainMatch(string domain, string url)
+		{
+			if (url.Contains(@"://")) {
+				url = url.Split(new[] { @"://" }, 2, StringSplitOptions.None)[1];
+			}
+			url = url.Split('/')[0];
+			return string.Compare(domain, url, StringComparison.OrdinalIgnoreCase) == 0;
+		}
 
 		/// <summary>
 		/// Returns the blocks of CSS within the documents supported CSS sources.<para/>

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -37,34 +37,12 @@ namespace PreMailer.Net
 		/// <param name="removeStyleElements">If set to <c>true</c> the style elements are removed.</param>
 		/// <param name="ignoreElements">CSS selector for STYLE elements to ignore (e.g. mobile-specific styles etc.)</param>
 		/// <param name="css">A string containing a style-sheet for inlining.</param>
-        /// <param name="stripIdAndClassAttributes">True to strip ID and class attributes</param>
-        /// <returns>Returns the html input, with styles moved to inline attributes.</returns>
-		public static InlineResult MoveCssInline(string html, bool removeStyleElements = false, string ignoreElements = null, string css = null, bool stripIdAndClassAttributes = false)
+		/// <param name="stripIdAndClassAttributes">True to strip ID and class attributes</param>
+		/// <param name="removeComments">True to remove comments, false to leave them intact</param>
+		/// <returns>Returns the html input, with styles moved to inline attributes.</returns>
+		public static InlineResult MoveCssInline(string html, bool removeStyleElements = false, string ignoreElements = null, string css = null, bool stripIdAndClassAttributes = false, bool removeComments = false)
 		{
-		    return new PreMailer(html)
-		        .MoveCssInline(removeStyleElements, ignoreElements, css, stripIdAndClassAttributes)
-		        .Render();
-		}
-
-		/// <summary>
-		/// Renders the result and returns it
-		/// </summary>
-		/// <returns>Returns the html and warnings for the resulting html.</returns>
-		public InlineResult Render()
-		{
-			var html = _document.Render();
-			return new InlineResult(html, _warnings);
-		}
-
-		/// <summary>
-		/// Renders the result and returns it
-		/// </summary>
-		/// <param name="options">DOM rendering options</param>
-		/// <returns>Returns the html and warnings for the resulting html.</returns>
-		public InlineResult Render(DomRenderingOptions options)
-		{
-			var html = _document.Render(options);
-			return new InlineResult(html, _warnings);
+		    return new PreMailer(html).MoveCssInline(removeStyleElements, ignoreElements, css, stripIdAndClassAttributes, removeComments);
 		}
 
 		/// <summary>
@@ -74,8 +52,9 @@ namespace PreMailer.Net
 		/// <param name="ignoreElements">CSS selector for STYLE elements to ignore (e.g. mobile-specific styles etc.)</param>
 		/// <param name="css">A string containing a style-sheet for inlining.</param>
 		/// <param name="stripIdAndClassAttributes">True to strip ID and class attributes</param>
-		/// <returns>Reference to the instance so you can chain calls.</returns>
-		public PreMailer MoveCssInline(bool removeStyleElements = false, string ignoreElements = null, string css = null, bool stripIdAndClassAttributes = false)
+		/// <param name="removeComments">True to remove comments, false to leave them intact</param>
+		/// <returns>Returns the html input, with styles moved to inline attributes.</returns>
+		public InlineResult MoveCssInline(bool removeStyleElements = false, string ignoreElements = null, string css = null, bool stripIdAndClassAttributes = false, bool removeComments = false)
 		{
 			// Store the variables used for inlining the CSS
 			_removeStyleElements = removeStyleElements;
@@ -102,7 +81,8 @@ namespace PreMailer.Net
 			if (_stripIdAndClassAttributes)
 				StripElementAttributes("id", "class");
 
-			return this;
+			var html = _document.Render(removeComments ? DomRenderingOptions.RemoveComments : DomRenderingOptions.Default);
+			return new InlineResult(html, _warnings);
 		}
 
 		/// <summary>

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -4,17 +4,16 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Text;
 
 namespace PreMailer.Net
 {
 	public class PreMailer
 	{
 		private readonly CQ _document;
-		private readonly bool _removeStyleElements;
-		private readonly bool _stripIdAndClassAttributes;
-		private readonly string _ignoreElements;
-		private readonly string _css;
+		private bool _removeStyleElements;
+		private bool _stripIdAndClassAttributes;
+		private string _ignoreElements;
+		private string _css;
 		private readonly CssParser _cssParser;
 		private readonly CssSelectorParser _cssSelectorParser;
 		private readonly List<string> _warnings;
@@ -23,19 +22,10 @@ namespace PreMailer.Net
         /// Constructor for the PreMailer class
         /// </summary>
         /// <param name="html">The HTML input.</param>
-        /// <param name="removeStyleElements">If set to <c>true</c> the style elements are removed.</param>
-        /// <param name="ignoreElements">CSS selector for STYLE elements to ignore (e.g. mobile-specific styles etc.)</param>
-        /// <param name="css">A string containing a style-sheet for inlining.</param>
-        /// <param name="stripIdAndClassAttributes">True to strip ID and class attributes</param>
-		public PreMailer(string html, bool removeStyleElements = false, string ignoreElements = null, string css = null, bool stripIdAndClassAttributes = false)
+		public PreMailer(string html)
 		{
 			_document = CQ.CreateDocument(html);
-			_removeStyleElements = removeStyleElements;
-			_stripIdAndClassAttributes = stripIdAndClassAttributes;
-			_ignoreElements = ignoreElements;
-			_css = css;
 			_warnings = new List<string>();
-
 			_cssParser = new CssParser();
 			_cssSelectorParser = new CssSelectorParser();
 		}
@@ -51,8 +41,8 @@ namespace PreMailer.Net
         /// <returns>Returns the html input, with styles moved to inline attributes.</returns>
 		public static InlineResult MoveCssInline(string html, bool removeStyleElements = false, string ignoreElements = null, string css = null, bool stripIdAndClassAttributes = false)
 		{
-		    return new PreMailer(html, removeStyleElements, ignoreElements, css, stripIdAndClassAttributes)
-		        .MoveCssInline()
+		    return new PreMailer(html)
+		        .MoveCssInline(removeStyleElements, ignoreElements, css, stripIdAndClassAttributes)
 		        .Render();
 		}
 
@@ -78,12 +68,22 @@ namespace PreMailer.Net
             return new InlineResult(html, _warnings);
         }
 
-        /// <summary>
-        /// Move all the CSS inline for this email
-        /// </summary>
+		/// <summary>
+		/// In-lines the CSS for the current HTML
+		/// </summary>
+		/// <param name="removeStyleElements">If set to <c>true</c> the style elements are removed.</param>
+		/// <param name="ignoreElements">CSS selector for STYLE elements to ignore (e.g. mobile-specific styles etc.)</param>
+		/// <param name="css">A string containing a style-sheet for inlining.</param>
+        /// <param name="stripIdAndClassAttributes">True to strip ID and class attributes</param>
         /// <returns>Reference to the instance so you can chain calls.</returns>
-        public PreMailer MoveCssInline()
+		public PreMailer MoveCssInline(bool removeStyleElements = false, string ignoreElements = null, string css = null, bool stripIdAndClassAttributes = false)
 		{
+            // Store the variables used for inlining the CSS
+            _removeStyleElements = removeStyleElements;
+            _stripIdAndClassAttributes = stripIdAndClassAttributes;
+            _ignoreElements = ignoreElements;
+            _css = css;
+
 			// Gather all of the CSS that we can work with.
 			var cssSourceNodes = CssSourceNodes();
 			var cssSources = ConvertToStyleSources(cssSourceNodes);


### PR DESCRIPTION
We are using PreMailer to inline our CSS, but also need to add Analytics tags. It is a lot more overhead per email to re-parse the entire HTML all over again with another instance of CsQuery to do the analytics tags processing, so it works faster if we moved our code for this into PreMailer. Plus I hope someone else will find this useful.