### PR TITLE
Compiled Regexes for speed

### DIFF
--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -106,9 +106,9 @@ namespace PreMailer.Net
             }
         }
 
-		private static Regex FillStyleClassRegex = new Regex(@"(;)(?=(?:[^""']|[""|'][^""']*"")*$)", RegexOptions.Multiline);
-	    private static Regex CssCommentRegex = new Regex(@"(?:/\*(.|[\r\n])*?\*/)|(?:(?<!url\s*\([^)]*)//.*)");
-		private static Regex UnsupportedAtRuleRegex = new Regex(@"(?:@charset [^;]*;)|(?:@(page|font-face)[^{]*{[^}]*})|@import.+?;", RegexOptions.IgnoreCase);
+		private static Regex FillStyleClassRegex = new Regex(@"(;)(?=(?:[^""']|[""|'][^""']*"")*$)", RegexOptions.Multiline | RegexOptions.Compiled);
+		private static Regex CssCommentRegex = new Regex(@"(?:/\*(.|[\r\n])*?\*/)|(?:(?<!url\s*\([^)]*)//.*)", RegexOptions.Compiled);
+		private static Regex UnsupportedAtRuleRegex = new Regex(@"(?:@charset [^;]*;)|(?:@(page|font-face)[^{]*{[^}]*})|@import.+?;", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private string CleanUp(string s)
         {
@@ -120,8 +120,8 @@ namespace PreMailer.Net
             return temp;
         }
 
-        public static Regex SupportedMediaQueriesRegex = new Regex(@"^(?:\s*(?:only\s+)?(?:screen|projection|all),\s*)*(?:(?:only\s+)?(?:screen|projection|all))$", RegexOptions.IgnoreCase);
-		private static Regex MediaQueryRegex = new Regex(@"@media\s*(?<query>[^{]*){(?<styles>(?>[^{}]+|{(?<DEPTH>)|}(?<-DEPTH>))*(?(DEPTH)(?!)))}");
+		public static Regex SupportedMediaQueriesRegex = new Regex(@"^(?:\s*(?:only\s+)?(?:screen|projection|all),\s*)*(?:(?:only\s+)?(?:screen|projection|all))$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+		private static Regex MediaQueryRegex = new Regex(@"@media\s*(?<query>[^{]*){(?<styles>(?>[^{}]+|{(?<DEPTH>)|}(?<-DEPTH>))*(?(DEPTH)(?!)))}", RegexOptions.Compiled);
 
         private string CleanupMediaQueries(string s)
         {

--- a/PreMailer.Net/PreMailer.Net/CssSelector.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSelector.cs
@@ -4,7 +4,7 @@ namespace PreMailer.Net
 {
 	public class CssSelector
 	{
-		protected static Regex NotMatcher = new Regex(@":not\((.+)\)", RegexOptions.IgnoreCase);
+		protected static Regex NotMatcher = new Regex(@":not\((.+)\)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
 		public string Selector { get; protected set; }
 

--- a/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
@@ -8,12 +8,13 @@ namespace PreMailer.Net
 {
     public class CssSelectorParser : ICssSelectorParser
     {
-        private static readonly Regex IdMatcher = BuildRegex(@"#([\w]+)");
-        private static readonly Regex AttribMatcher = BuildRegex(@"\[[\w=]+\]");
-        private static readonly Regex ClassMatcher = BuildRegex(@"\.([\w]+)");
-        private static readonly Regex ElemMatcher = BuildRegex(@"[a-zA-Z]+");
-        private static readonly Regex PseudoClassMatcher = BuildOrRegex(PseudoClasses, ":", x => x.Replace("()", @"\(\w+\)"));
-        private static readonly Regex PseudoElemMatcher = BuildOrRegex(PseudoElements, "::?");
+		private static readonly Regex IdMatcher = new Regex(@"#([\w]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+		private static readonly Regex AttribMatcher = new Regex(@"\[[\w=]+\]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+		private static readonly Regex ClassMatcher = new Regex(@"\.([\w]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+		private static readonly Regex ElemMatcher = new Regex(@"[a-zA-Z]+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+		private static readonly Regex PseudoClassMatcher = BuildOrRegex(PseudoClasses, ":", x => x.Replace("()", @"\(\w+\)"));
+		private static readonly Regex PseudoElemMatcher = BuildOrRegex(PseudoElements, "::?");
+		private static readonly Regex PseudoUnimplemented = BuildOrRegex(UnimplementedPseudoSelectors, "::?");
 
         /// <summary>
         /// Static method to quickly find the specificity of a single CSS selector.<para/>
@@ -81,8 +82,7 @@ namespace PreMailer.Net
         /// <remarks>See https://github.com/jamietre/CsQuery#features for more information.</remarks>
         public bool IsSupportedSelector(string key)
         {
-            var psuedo = BuildOrRegex(UnimplementedPseudoSelectors, "::?");
-            return !psuedo.IsMatch(key);
+			return !PseudoUnimplemented.IsMatch(key);
         }
 
         private static int MatchCountAndStrip(Regex regex, string selector, out string result)
@@ -182,11 +182,6 @@ namespace PreMailer.Net
             }
         }
 
-        private static Regex BuildRegex(string pattern)
-        {
-            return new Regex(pattern, RegexOptions.IgnoreCase);
-        }
-
         private static Regex BuildOrRegex(string[] items, string prefix, Func<string, string> mutator = null)
         {
             var sb = new StringBuilder();
@@ -208,7 +203,7 @@ namespace PreMailer.Net
             }
 
             sb.Append(")");
-            return new Regex(sb.ToString(), RegexOptions.IgnoreCase);
+            return new Regex(sb.ToString(), RegexOptions.IgnoreCase | RegexOptions.Compiled);
         }
     }
 }


### PR DESCRIPTION
Originally when I started fixing the static regex code to be compiled, performance was terrible. So I took it all out and made sure none of the regex'es were compiled. However going back and doing performance profiling on some other regex'es we use I discovered that compiled regex'es are in fact faster, when you need to use them over and over. There is a performance hit the first time a regex is used as it is compiled, but every time after that it is always faster than the non-compiled ones.

Since PreMailer is really intended to be used for batch processing of emails or in code that is going to re-use the static regex'es over and over again (like a web site sending emails in response to customer input), it makes sense to have them all compiled. 

The core reason the performance as so terrible last time I tried is that I missed the BuildOrRegex() call in IsSupportedSelector(), which was not using a static regex at all. Once I changed that to a static regex, for the test HTML in my performance tests moving the CSS inline is faster with compiled regex'es than not compiled (about 11% faster). It may not seem like much, but if you are processing thousands of emails for sending newsletters, it all adds up :)