### PR TITLE
Added support for premailer-specific CSS

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -190,6 +190,26 @@ namespace PreMailer.Net.Tests
         }
 
         [TestMethod]
+		public void MoveCssInline_AddSpecial()
+        {
+			string input = "<html><head><style type=\"text/css\">.test { padding: 7px; -premailer-cellspacing: 5; -premailer-width: 14%; }</style></head><body><table><tr><td class=\"test\"></td></tr></table></body></html>";
+
+            var premailedOutput = PreMailer.MoveCssInline(input, false);
+
+			Assert.IsTrue(premailedOutput.Html.Contains("<td class=\"test\" style=\"padding: 7px\" cellspacing=\"5\" width=\"14%\">"), "Actual: " + premailedOutput.Html);
+        }
+
+        [TestMethod]
+        public void MoveCssInline_AddSpecial_RemoveEmptyStyle()
+        {
+			string input = "<html><head><style type=\"text/css\">.test { -premailer-cellspacing: 5; -premailer-width: 14%; }</style></head><body><table><tr><td class=\"test\"></td></tr></table></body></html>";
+
+            var premailedOutput = PreMailer.MoveCssInline(input, false);
+
+			Assert.IsTrue(premailedOutput.Html.Contains("<td class=\"test\" cellspacing=\"5\" width=\"14%\">"), "Actual: " + premailedOutput.Html);
+        }
+
+        [TestMethod]
         public void MoveCssInline_AddBgColorStyle_IgnoreElementWithBackgroundColorAndNoBgColor()
         {
             string input = "<html><head><style type=\"text/css\">.test { background-color:#f1f1f1; }</style></head><body><table><tr><td class=\"test\"></td></tr></table></body></html>";

--- a/PreMailer.Net/PreMailer.Net/CssElementStyleResolver.cs
+++ b/PreMailer.Net/PreMailer.Net/CssElementStyleResolver.cs
@@ -1,20 +1,47 @@
 using System.Collections.Generic;
+using System.Linq;
 using CsQuery;
 
 namespace PreMailer.Net
 {
    public class CssElementStyleResolver
    {
-        public static IEnumerable<AttributeToCss> GetAllStyles(IDomObject domElement, StyleClass styleClass)
-        {
-            var attributeCssList = new List<AttributeToCss>
-                {
-                    new AttributeToCss {AttributeName = "style", CssValue = styleClass.ToString()}
-                };
+	   private const string premailerAttributePrefix = "-premailer-";
 
-            attributeCssList.AddRange(CssStyleEquivalence.FindEquivalent(domElement, styleClass));
+	   public static IEnumerable<AttributeToCss> GetAllStyles(IDomObject domElement, StyleClass styleClass)
+        {
+	        var attributeCssList = new List<AttributeToCss>();
+
+	        AddSpecialPremailerAttributes(attributeCssList, styleClass);
+
+		   if (styleClass.Attributes.Count > 0)
+			   attributeCssList.Add(new AttributeToCss { AttributeName = "style", CssValue = styleClass.ToString() });
+
+		   attributeCssList.AddRange(CssStyleEquivalence.FindEquivalent(domElement, styleClass));
 
             return attributeCssList;
         }
-    }
+
+	   private static void AddSpecialPremailerAttributes(List<AttributeToCss> attributeCssList, StyleClass styleClass)
+	   {
+		   while (true)
+		   {
+			   var premailerRuleMatch = styleClass.Attributes.FirstOrDefault(a => a.Key.StartsWith(premailerAttributePrefix));
+
+			   var key = premailerRuleMatch.Key;
+			   var cssAttribute = premailerRuleMatch.Value;
+
+			   if (key == null)
+				   break;
+
+			   attributeCssList.Add(new AttributeToCss
+			   {
+				   AttributeName = key.Replace(premailerAttributePrefix, ""),
+				   CssValue = cssAttribute.Value
+			   });
+
+			   styleClass.Attributes.Remove(key);
+		   }
+	   }
+   }
 }

--- a/PreMailer.Net/PreMailer.Net/StyleClassApplier.cs
+++ b/PreMailer.Net/PreMailer.Net/StyleClassApplier.cs
@@ -25,6 +25,9 @@ namespace PreMailer.Net
                 //domElement.SetAttribute(attributeToCss.AttributeName, attributeToCss.CssValue);
             }
 
+	        if (string.IsNullOrEmpty(domElement.Attributes["style"]))
+		        domElement.RemoveAttribute("style");
+
             return domElement;
         }
 


### PR DESCRIPTION
For example:

table { -premailer-cellspacing: 5; -premailer-width: 500; }

will result in

<table cellspacing="5" width="500">

Reference: https://github.com/premailer/premailer