### PR TITLE
Do not add Analytics tracking tags when using Handlebars syntax

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -263,8 +263,8 @@ namespace PreMailer.Net.Tests
 		[TestMethod]
 		public void AddAnalyticsTags_AddsTags()
 		{
-			const string input = @"<div><a href=""blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1"">Extra Stuff</a></div>";
-			const string expected = @"<html><head></head><body><div><a href=""blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1&utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Extra Stuff</a></div></body></html>";
+            const string input = @"<div><a href=""blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1"">Extra Stuff</a><a href=""{{Handlebars}}"">Don't Touch</a></div>";
+            const string expected = @"<html><head></head><body><div><a href=""blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1&utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Extra Stuff</a><a href=""{{Handlebars}}"">Don't Touch</a></div></body></html>";
 			var premailedOutput = new PreMailer(input)
 				.AddAnalyticsTags("source", "medium", "campaign", "content")
 				.MoveCssInline();
@@ -274,8 +274,8 @@ namespace PreMailer.Net.Tests
 		[TestMethod]
 		public void AddAnalyticsTags_AddsTagsAndExcludesDomain()
 		{
-			const string input = @"<div><a href=""http://www.blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""https://www.nomatch.com/someurl?extra=1"">Extra Stuff</a></div>";
-			const string expected = @"<html><head></head><body><div><a href=""http://www.blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""https://www.nomatch.com/someurl?extra=1"">Extra Stuff</a></div></body></html>";
+            const string input = @"<div><a href=""http://www.blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""https://www.nomatch.com/someurl?extra=1"">Extra Stuff</a><a href=""{{Handlebars}}"">Don't Touch</a></div>";
+            const string expected = @"<html><head></head><body><div><a href=""http://www.blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""https://www.nomatch.com/someurl?extra=1"">Extra Stuff</a><a href=""{{Handlebars}}"">Don't Touch</a></div></body></html>";
 			var premailedOutput = new PreMailer(input)
 				.AddAnalyticsTags("source", "medium", "campaign", "content", "www.Blah.com")
 				.MoveCssInline();

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -263,8 +263,8 @@ namespace PreMailer.Net.Tests
 		[TestMethod]
 		public void AddAnalyticsTags_AddsTags()
 		{
-            const string input = @"<div><a href=""blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1"">Extra Stuff</a><a href=""{{Handlebars}}"">Don't Touch</a></div>";
-            const string expected = @"<html><head></head><body><div><a href=""blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""blah.com/someurl?extra=1&utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Extra Stuff</a><a href=""{{Handlebars}}"">Don't Touch</a></div></body></html>";
+            const string input = @"<div><a href=""http://blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""http://blah.com/someurl?extra=1"">Extra Stuff</a><a href=""{{Handlebars}}"">Don't Touch</a></div>";
+            const string expected = @"<html><head></head><body><div><a href=""http://blah.com/someurl?utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Some URL</a><a>No href</a></div><div><a href=""http://blah.com/someurl?extra=1&utm_source=source&utm_medium=medium&utm_campaign=campaign&utm_content=content"">Extra Stuff</a><a href=""{{Handlebars}}"">Don't Touch</a></div></body></html>";
 			var premailedOutput = new PreMailer(input)
 				.AddAnalyticsTags("source", "medium", "campaign", "content")
 				.MoveCssInline();

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -100,7 +100,7 @@ namespace PreMailer.Net
 			foreach (var tag in _document["a[href]"])
 			{
 				var href = tag.Attributes["href"];
-				if (domain == null || DomainMatch(domain, href))
+				if (!href.StartsWith("{{") && (domain == null || DomainMatch(domain, href)))
 				{
 					tag.SetAttribute("href", href + (href.IndexOf("?", StringComparison.Ordinal) >= 0 ? "&" : "?") + tracking);
 				}

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -100,7 +100,7 @@ namespace PreMailer.Net
 			foreach (var tag in _document["a[href]"])
 			{
 				var href = tag.Attributes["href"];
-				if (href.StartsWith("http") && (domain == null || DomainMatch(domain, href)))
+				if (href.StartsWith("http", StringComparison.OrdinalIgnoreCase) && (domain == null || DomainMatch(domain, href)))
 				{
 					tag.SetAttribute("href", href + (href.IndexOf("?", StringComparison.Ordinal) >= 0 ? "&" : "?") + tracking);
 				}

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -100,7 +100,7 @@ namespace PreMailer.Net
 			foreach (var tag in _document["a[href]"])
 			{
 				var href = tag.Attributes["href"];
-				if (!href.StartsWith("{{") && (domain == null || DomainMatch(domain, href)))
+				if (href.StartsWith("http") && (domain == null || DomainMatch(domain, href)))
 				{
 					tag.SetAttribute("href", href + (href.IndexOf("?", StringComparison.Ordinal) >= 0 ? "&" : "?") + tracking);
 				}


### PR DESCRIPTION
I found a way to run all the Pre-Mailer stuff prior to rendering our Handlebars templates, but that means we need to remove the analytics tracking tags from URL generated by the template (we assume the caller decorates the URL's correctly).