### PR TITLE
Add Position property to StyleClass class.

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/CssParserTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssParserTests.cs
@@ -146,15 +146,30 @@ namespace PreMailer.Net.Tests
         [TestMethod]
         public void AddStylesheet_ContainsEncodedImage()
         {
-            var stylesheet = @"#logo 
-{ 
-    content: url('data:image/jpeg; base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='); 
-    max-width: 200px; 
-    height: auto; 
+            var stylesheet = @"#logo
+{
+    content: url('data:image/jpeg; base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=');
+    max-width: 200px;
+    height: auto;
 }";
             var parser = new CssParser();
             parser.AddStyleSheet(stylesheet);
             var attributes = parser.Styles["#logo"].Attributes;
+        }
+
+        [TestMethod]
+        public void AddStylesheet_ShouldSetStyleClassPositions()
+        {
+            var stylesheet1 = "#id .class1 element { color: #fff; } #id .class2 element { color: #aaa; }";
+            var stylesheet2 = "#id .class3 element { color: #000; } #id .class2 element { color: #bbb; }";
+            var parser = new CssParser();
+
+            parser.AddStyleSheet(stylesheet1);
+            parser.AddStyleSheet(stylesheet2);
+
+            Assert.AreEqual(1, parser.Styles.Values[0].Position);
+            Assert.AreEqual(4, parser.Styles.Values[1].Position);
+            Assert.AreEqual(3, parser.Styles.Values[2].Position);
         }
     }
 }

--- a/PreMailer.Net/PreMailer.Net.Tests/CssParserTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssParserTests.cs
@@ -2,174 +2,174 @@
 
 namespace PreMailer.Net.Tests
 {
-    [TestClass]
-    public class CssParserTests
-    {
-        [TestMethod]
-        public void AddStylesheet_ContainsAtCharsetRule_ShouldStripRuleAndParseStylesheet()
-        {
-            var stylesheet = "@charset utf-8; div { width: 100% }";
+	[TestClass]
+	public class CssParserTests
+	{
+		[TestMethod]
+		public void AddStylesheet_ContainsAtCharsetRule_ShouldStripRuleAndParseStylesheet()
+		{
+			var stylesheet = "@charset utf-8; div { width: 100% }";
 
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
 
-            Assert.IsTrue(parser.Styles.ContainsKey("div"));
-        }
+			Assert.IsTrue(parser.Styles.ContainsKey("div"));
+		}
 
-        [TestMethod]
-        public void AddStylesheet_ContainsAtPageSection_ShouldStripRuleAndParseStylesheet()
-        {
-            var stylesheet = "@page :first { margin: 2in 3in; } div { width: 100% }";
+		[TestMethod]
+		public void AddStylesheet_ContainsAtPageSection_ShouldStripRuleAndParseStylesheet()
+		{
+			var stylesheet = "@page :first { margin: 2in 3in; } div { width: 100% }";
 
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
 
-            Assert.AreEqual(1, parser.Styles.Count);
-            Assert.IsTrue(parser.Styles.ContainsKey("div"));
-        }
+			Assert.AreEqual(1, parser.Styles.Count);
+			Assert.IsTrue(parser.Styles.ContainsKey("div"));
+		}
 
-        [TestMethod]
-        public void AddStylesheet_ContainsUnsupportedMediaQuery_ShouldStrip()
-        {
-            var stylesheet = "@media print { div { width: 90%; } }";
+		[TestMethod]
+		public void AddStylesheet_ContainsUnsupportedMediaQuery_ShouldStrip()
+		{
+			var stylesheet = "@media print { div { width: 90%; } }";
 
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
 
-            Assert.AreEqual(0, parser.Styles.Count);
-        }
+			Assert.AreEqual(0, parser.Styles.Count);
+		}
 
-        [TestMethod]
-        public void AddStylesheet_ContainsUnsupportedMediaQueryAndNormalRules_ShouldStripMediaQueryAndParseRules()
-        {
-            var stylesheet = "div { width: 600px; } @media only screen and (max-width:620px) { div { width: 100% } } p { font-family: serif; }";
+		[TestMethod]
+		public void AddStylesheet_ContainsUnsupportedMediaQueryAndNormalRules_ShouldStripMediaQueryAndParseRules()
+		{
+			var stylesheet = "div { width: 600px; } @media only screen and (max-width:620px) { div { width: 100% } } p { font-family: serif; }";
 
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
 
-            Assert.AreEqual(2, parser.Styles.Count);
+			Assert.AreEqual(2, parser.Styles.Count);
 
-            Assert.IsTrue(parser.Styles.ContainsKey("div"));
-            Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
+			Assert.IsTrue(parser.Styles.ContainsKey("div"));
+			Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
 
-            Assert.IsTrue(parser.Styles.ContainsKey("p"));
-            Assert.AreEqual("serif", parser.Styles["p"].Attributes["font-family"].Value);
-        }
+			Assert.IsTrue(parser.Styles.ContainsKey("p"));
+			Assert.AreEqual("serif", parser.Styles["p"].Attributes["font-family"].Value);
+		}
 
-        [TestMethod]
-        public void AddStylesheet_ContainsSupportedMediaQuery_ShouldParseQueryRules()
-        {
-            var stylesheet = "@media only screen { div { width: 600px; } }";
+		[TestMethod]
+		public void AddStylesheet_ContainsSupportedMediaQuery_ShouldParseQueryRules()
+		{
+			var stylesheet = "@media only screen { div { width: 600px; } }";
 
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
 
-            Assert.AreEqual(1, parser.Styles.Count);
+			Assert.AreEqual(1, parser.Styles.Count);
 
-            Assert.IsTrue(parser.Styles.ContainsKey("div"));
-            Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
-        }
+			Assert.IsTrue(parser.Styles.ContainsKey("div"));
+			Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
+		}
 
-        [TestMethod]
-        public void AddStylesheet_ContainsImportStatement_ShouldStripOutImportStatement()
-        {
-            var stylesheet = "@import url(http://google.com/stylesheet); div { width : 600px; }";
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
-            Assert.AreEqual(1, parser.Styles.Count);
+		[TestMethod]
+		public void AddStylesheet_ContainsImportStatement_ShouldStripOutImportStatement()
+		{
+			var stylesheet = "@import url(http://google.com/stylesheet); div { width : 600px; }";
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
+			Assert.AreEqual(1, parser.Styles.Count);
 
-            Assert.IsTrue(parser.Styles.ContainsKey("div"));
-            Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
-        }
+			Assert.IsTrue(parser.Styles.ContainsKey("div"));
+			Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
+		}
 
 
-        [TestMethod]
-        public void AddStylesheet_ContainsImportStatementTest_ShouldStripOutImportStatement()
-        {
-            var stylesheet = "@import 'stylesheet.css'; div { width : 600px; }";
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
-            Assert.AreEqual(1, parser.Styles.Count);
+		[TestMethod]
+		public void AddStylesheet_ContainsImportStatementTest_ShouldStripOutImportStatement()
+		{
+			var stylesheet = "@import 'stylesheet.css'; div { width : 600px; }";
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
+			Assert.AreEqual(1, parser.Styles.Count);
 
-            Assert.IsTrue(parser.Styles.ContainsKey("div"));
-            Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
-        }
+			Assert.IsTrue(parser.Styles.ContainsKey("div"));
+			Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
+		}
 
-        [TestMethod]
-        public void AddStylesheet_ContainsMinifiedImportStatement_ShouldStripOutImportStatement()
-        {
-            var stylesheet = "@import url(http://google.com/stylesheet);div{width:600px;}";
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
-            Assert.AreEqual(1, parser.Styles.Count);
+		[TestMethod]
+		public void AddStylesheet_ContainsMinifiedImportStatement_ShouldStripOutImportStatement()
+		{
+			var stylesheet = "@import url(http://google.com/stylesheet);div{width:600px;}";
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
+			Assert.AreEqual(1, parser.Styles.Count);
 
-            Assert.IsTrue(parser.Styles.ContainsKey("div"));
-            Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
-        }
+			Assert.IsTrue(parser.Styles.ContainsKey("div"));
+			Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
+		}
 
-        [TestMethod]
-        public void AddStylesheet_ContainsMultipleImportStatement_ShouldStripOutImportStatements()
-        {
-            var stylesheet = "@import url(http://google.com/stylesheet); @import url(http://jquery.com/stylesheet1); @import url(http://amazon.com/stylesheet2); div { width : 600px; }";
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
-            Assert.AreEqual(1, parser.Styles.Count);
+		[TestMethod]
+		public void AddStylesheet_ContainsMultipleImportStatement_ShouldStripOutImportStatements()
+		{
+			var stylesheet = "@import url(http://google.com/stylesheet); @import url(http://jquery.com/stylesheet1); @import url(http://amazon.com/stylesheet2); div { width : 600px; }";
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
+			Assert.AreEqual(1, parser.Styles.Count);
 
-            Assert.IsTrue(parser.Styles.ContainsKey("div"));
-            Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
-        }
+			Assert.IsTrue(parser.Styles.ContainsKey("div"));
+			Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
+		}
 
-        [TestMethod]
-        public void AddStylesheet_ContainsImportStatementWithMediaQuery_ShouldStripOutImportStatements()
-        {
-            var stylesheet = "@import url(http://google.com/stylesheet) mobile; div { width : 600px; }";
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
-            Assert.AreEqual(1, parser.Styles.Count);
+		[TestMethod]
+		public void AddStylesheet_ContainsImportStatementWithMediaQuery_ShouldStripOutImportStatements()
+		{
+			var stylesheet = "@import url(http://google.com/stylesheet) mobile; div { width : 600px; }";
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
+			Assert.AreEqual(1, parser.Styles.Count);
 
-            Assert.IsTrue(parser.Styles.ContainsKey("div"));
-            Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
-        }
+			Assert.IsTrue(parser.Styles.ContainsKey("div"));
+			Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
+		}
 
-        [TestMethod]
-        public void AddStylesheet_ContainsMuiltpleImportStatementWithMediaQuerys_ShouldStripOutImportStatements()
-        {
-            var stylesheet = "@import url(http://google.com/stylesheet) mobile; @import url(http://google.com/stylesheet) mobile; @import url(http://google.com/stylesheet) mobile; div { width : 600px; }";
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
-            Assert.AreEqual(1, parser.Styles.Count);
+		[TestMethod]
+		public void AddStylesheet_ContainsMuiltpleImportStatementWithMediaQuerys_ShouldStripOutImportStatements()
+		{
+			var stylesheet = "@import url(http://google.com/stylesheet) mobile; @import url(http://google.com/stylesheet) mobile; @import url(http://google.com/stylesheet) mobile; div { width : 600px; }";
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
+			Assert.AreEqual(1, parser.Styles.Count);
 
-            Assert.IsTrue(parser.Styles.ContainsKey("div"));
-            Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
-        }
+			Assert.IsTrue(parser.Styles.ContainsKey("div"));
+			Assert.AreEqual("600px", parser.Styles["div"].Attributes["width"].Value);
+		}
 
-        [TestMethod]
-        public void AddStylesheet_ContainsEncodedImage()
-        {
-            var stylesheet = @"#logo
+		[TestMethod]
+		public void AddStylesheet_ContainsEncodedImage()
+		{
+			var stylesheet = @"#logo
 {
-    content: url('data:image/jpeg; base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=');
-    max-width: 200px;
-    height: auto;
+	content: url('data:image/jpeg; base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=');
+	max-width: 200px;
+	height: auto;
 }";
-            var parser = new CssParser();
-            parser.AddStyleSheet(stylesheet);
-            var attributes = parser.Styles["#logo"].Attributes;
-        }
+			var parser = new CssParser();
+			parser.AddStyleSheet(stylesheet);
+			var attributes = parser.Styles["#logo"].Attributes;
+		}
 
-        [TestMethod]
-        public void AddStylesheet_ShouldSetStyleClassPositions()
-        {
-            var stylesheet1 = "#id .class1 element { color: #fff; } #id .class2 element { color: #aaa; }";
-            var stylesheet2 = "#id .class3 element { color: #000; } #id .class2 element { color: #bbb; }";
-            var parser = new CssParser();
+		[TestMethod]
+		public void AddStylesheet_ShouldSetStyleClassPositions()
+		{
+			var stylesheet1 = "#id .class1 element { color: #fff; } #id .class2 element { color: #aaa; }";
+			var stylesheet2 = "#id .class3 element { color: #000; } #id .class2 element { color: #bbb; }";
+			var parser = new CssParser();
 
-            parser.AddStyleSheet(stylesheet1);
-            parser.AddStyleSheet(stylesheet2);
+			parser.AddStyleSheet(stylesheet1);
+			parser.AddStyleSheet(stylesheet2);
 
-            Assert.AreEqual(1, parser.Styles.Values[0].Position);
-            Assert.AreEqual(4, parser.Styles.Values[1].Position);
-            Assert.AreEqual(3, parser.Styles.Values[2].Position);
-        }
-    }
+			Assert.AreEqual(1, parser.Styles.Values[0].Position);
+			Assert.AreEqual(4, parser.Styles.Values[1].Position);
+			Assert.AreEqual(3, parser.Styles.Values[2].Position);
+		}
+	}
 }

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -265,6 +265,19 @@ namespace PreMailer.Net.Tests
         [TestMethod]
         public void MoveCssInline_LaterPositionStylesWithEqualSpecificityHasPrecedence_InSameBlock()
         {
+            string input1 = "<html><head><style type=\"text/css\">table.acolor td { color: #0F0; } table.bcolor td { color: #00F; }</style></head><body><table class=\"acolor bcolor\"><tr><td>test</td></tr></table></body></html>";
+            string input2 = "<html><head><style type=\"text/css\">table.bcolor td { color: #00F; } table.acolor td { color: #0F0; }</style></head><body><table class=\"acolor bcolor\"><tr><td>test</td></tr></table></body></html>";
+
+            var premailedOutput1 = PreMailer.MoveCssInline(input1, false);
+            var premailedOutput2 = PreMailer.MoveCssInline(input2, false);
+            
+            Assert.IsTrue(premailedOutput1.Html.Contains("<td style=\"color: #00F\">test</td>"));
+            Assert.IsTrue(premailedOutput2.Html.Contains("<td style=\"color: #0F0\">test</td>"));
+        }
+
+        [TestMethod]
+        public void MoveCssInline_LaterPositionStylesWithEqualSpecificityHasPrecedence_Nested_InSameBlock()
+        {
             string input1 = "<html><head><style type=\"text/css\">table.child td { color: #00F; } table.parent td { color: #0F0; }</style></head><body><table class=\"parent\"><tr><td><table class=\"child\"><tr><td>test</td></tr></table></td></tr></table></body></html>";
             string input2 = "<html><head><style type=\"text/css\">table.parent td { color: #0F0; } table.child td { color: #00F; }</style></head><body><table class=\"parent\"><tr><td><table class=\"child\"><tr><td>test</td></tr></table></td></tr></table></body></html>";
 
@@ -277,6 +290,19 @@ namespace PreMailer.Net.Tests
 
         [TestMethod]
         public void MoveCssInline_LaterPositionStylesWithEqualSpecificityHasPrecedence_InSeparateBlocks()
+        {
+            string input1 = "<html><head><style type=\"text/css\">table.acolor td { color: #00F; }</style><style type=\"text/css\">table.bcolor td { color: #0F0; }</style></head><body><table class=\"acolor bcolor\"><tr><td>test</td></tr></table></body></html>";
+            string input2 = "<html><head><style type=\"text/css\">table.bcolor td { color: #0F0; }</style><style type=\"text/css\">table.acolor td { color: #00F; }</style></head><body><table class=\"acolor bcolor\"><tr><td>test</td></tr></table></body></html>";
+
+            var premailedOutput1 = PreMailer.MoveCssInline(input1, false);
+            var premailedOutput2 = PreMailer.MoveCssInline(input2, false);
+
+            Assert.IsTrue(premailedOutput1.Html.Contains("<td style=\"color: #0F0\">test</td>"));
+            Assert.IsTrue(premailedOutput2.Html.Contains("<td style=\"color: #00F\">test</td>"));
+        }
+
+        [TestMethod]
+        public void MoveCssInline_LaterPositionStylesWithEqualSpecificityHasPrecedence_Nested_InSeparateBlocks()
         {
             string input1 = "<html><head><style type=\"text/css\">table.child td { color: #00F; } table.parent td { color: #00F; }</style><style type=\"text/css\">table.parent td { color: #0F0; }</style></head><body><table class=\"parent\"><tr><td><table class=\"child\"><tr><td>test</td></tr></table></td></tr></table></body></html>";
             string input2 = "<html><head><style type=\"text/css\">table.parent td { color: #0F0; } table.child td { color: #0F0; }</style><style type=\"text/css\">table.child td { color: #00F; }</style></head><body><table class=\"parent\"><tr><td><table class=\"child\"><tr><td>test</td></tr></table></td></tr></table></body></html>";

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -262,18 +262,18 @@ namespace PreMailer.Net.Tests
 			Assert.IsTrue(expected == premailedOutput.Html);
 		}
 
-        [TestMethod]
-        public void MoveCssInline_LaterPositionStylesWithEqualSpecificityHasPrecedence_InSameBlock()
-        {
-            string input1 = "<html><head><style type=\"text/css\">table.acolor td { color: #0F0; } table.bcolor td { color: #00F; }</style></head><body><table class=\"acolor bcolor\"><tr><td>test</td></tr></table></body></html>";
-            string input2 = "<html><head><style type=\"text/css\">table.bcolor td { color: #00F; } table.acolor td { color: #0F0; }</style></head><body><table class=\"acolor bcolor\"><tr><td>test</td></tr></table></body></html>";
+		[TestMethod]
+		public void MoveCssInline_LaterPositionStylesWithEqualSpecificityHasPrecedence_InSameBlock()
+		{
+			string input1 = "<html><head><style type=\"text/css\">table.acolor td { color: #0F0; } table.bcolor td { color: #00F; }</style></head><body><table class=\"acolor bcolor\"><tr><td>test</td></tr></table></body></html>";
+			string input2 = "<html><head><style type=\"text/css\">table.bcolor td { color: #00F; } table.acolor td { color: #0F0; }</style></head><body><table class=\"acolor bcolor\"><tr><td>test</td></tr></table></body></html>";
 
-            var premailedOutput1 = PreMailer.MoveCssInline(input1, false);
-            var premailedOutput2 = PreMailer.MoveCssInline(input2, false);
-            
-            Assert.IsTrue(premailedOutput1.Html.Contains("<td style=\"color: #00F\">test</td>"));
-            Assert.IsTrue(premailedOutput2.Html.Contains("<td style=\"color: #0F0\">test</td>"));
-        }
+			var premailedOutput1 = PreMailer.MoveCssInline(input1, false);
+			var premailedOutput2 = PreMailer.MoveCssInline(input2, false);
+
+			Assert.IsTrue(premailedOutput1.Html.Contains("<td style=\"color: #00F\">test</td>"));
+			Assert.IsTrue(premailedOutput2.Html.Contains("<td style=\"color: #0F0\">test</td>"));
+		}
 
         [TestMethod]
         public void MoveCssInline_LaterPositionStylesWithEqualSpecificityHasPrecedence_Nested_InSameBlock()

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -262,7 +262,33 @@ namespace PreMailer.Net.Tests
 			Assert.IsTrue(expected == premailedOutput.Html);
 		}
 
-		[TestMethod]
+        [TestMethod]
+        public void MoveCssInline_LaterPositionStylesWithEqualSpecificityHasPrecedence_InSameBlock()
+        {
+            string input1 = "<html><head><style type=\"text/css\">table.child td { color: #00F; } table.parent td { color: #0F0; }</style></head><body><table class=\"parent\"><tr><td><table class=\"child\"><tr><td>test</td></tr></table></td></tr></table></body></html>";
+            string input2 = "<html><head><style type=\"text/css\">table.parent td { color: #0F0; } table.child td { color: #00F; }</style></head><body><table class=\"parent\"><tr><td><table class=\"child\"><tr><td>test</td></tr></table></td></tr></table></body></html>";
+
+            var premailedOutput1 = PreMailer.MoveCssInline(input1, false);
+            var premailedOutput2 = PreMailer.MoveCssInline(input2, false);
+
+            Assert.IsTrue(premailedOutput1.Html.Contains("<td style=\"color: #0F0\">test</td>"));
+            Assert.IsTrue(premailedOutput2.Html.Contains("<td style=\"color: #00F\">test</td>"));
+        }
+
+        [TestMethod]
+        public void MoveCssInline_LaterPositionStylesWithEqualSpecificityHasPrecedence_InSeparateBlocks()
+        {
+            string input1 = "<html><head><style type=\"text/css\">table.child td { color: #00F; } table.parent td { color: #00F; }</style><style type=\"text/css\">table.parent td { color: #0F0; }</style></head><body><table class=\"parent\"><tr><td><table class=\"child\"><tr><td>test</td></tr></table></td></tr></table></body></html>";
+            string input2 = "<html><head><style type=\"text/css\">table.parent td { color: #0F0; } table.child td { color: #0F0; }</style><style type=\"text/css\">table.child td { color: #00F; }</style></head><body><table class=\"parent\"><tr><td><table class=\"child\"><tr><td>test</td></tr></table></td></tr></table></body></html>";
+
+            var premailedOutput1 = PreMailer.MoveCssInline(input1, false);
+            var premailedOutput2 = PreMailer.MoveCssInline(input2, false);
+
+            Assert.IsTrue(premailedOutput1.Html.Contains("<td style=\"color: #0F0\">test</td>"));
+            Assert.IsTrue(premailedOutput2.Html.Contains("<td style=\"color: #00F\">test</td>"));
+        }
+
+        [TestMethod]
 		public void AddAnalyticsTags_AddsTags()
 		{
 			const string input = @"<div><a href=""http://blah.com/someurl"">Some URL</a><a>No href</a></div><div><a href=""http://blah.com/someurl?extra=1"">Extra Stuff</a><a href=""{{Handlebars}}"">Don't Touch</a></div>";
@@ -332,5 +358,5 @@ namespace PreMailer.Net.Tests
 
 			Assert.IsTrue(premailedOutput.Html.Contains("<div class=\"test\" style=\"width: 150px\">"));
 		}
-	}
+    }
 }

--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -8,6 +8,7 @@ namespace PreMailer.Net
     {
         private readonly List<string> _styleSheets;
         private SortedList<string, StyleClass> _scc;
+        private int styleCount = 0;
 
         public SortedList<string, StyleClass> Styles
         {
@@ -77,6 +78,8 @@ namespace PreMailer.Net
                 {
                     sc = new StyleClass();
                 }
+
+                sc.Position = ++styleCount;
 
                 FillStyleClass(sc, styleName, parts[1]);
 

--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -4,135 +4,135 @@ using System.Text.RegularExpressions;
 
 namespace PreMailer.Net
 {
-    public class CssParser
-    {
-        private readonly List<string> _styleSheets;
-        private SortedList<string, StyleClass> _scc;
-        private int styleCount = 0;
+	public class CssParser
+	{
+		private readonly List<string> _styleSheets;
+		private SortedList<string, StyleClass> _scc;
+		private int styleCount = 0;
 
-        public SortedList<string, StyleClass> Styles
-        {
-            get { return _scc; }
-            set { _scc = value; }
-        }
+		public SortedList<string, StyleClass> Styles
+		{
+			get { return _scc; }
+			set { _scc = value; }
+		}
 
-        public CssParser()
-        {
-            _styleSheets = new List<string>();
-            _scc = new SortedList<string, StyleClass>();
-        }
+		public CssParser()
+		{
+			_styleSheets = new List<string>();
+			_scc = new SortedList<string, StyleClass>();
+		}
 
-        public void AddStyleSheet(string styleSheetContent)
-        {
-            _styleSheets.Add(styleSheetContent);
-            ProcessStyleSheet(styleSheetContent);
-        }
+		public void AddStyleSheet(string styleSheetContent)
+		{
+			_styleSheets.Add(styleSheetContent);
+			ProcessStyleSheet(styleSheetContent);
+		}
 
-        public string GetStyleSheet(int index)
-        {
-            return _styleSheets[index];
-        }
+		public string GetStyleSheet(int index)
+		{
+			return _styleSheets[index];
+		}
 
-        public StyleClass ParseStyleClass(string className, string style)
-        {
-            var sc = new StyleClass { Name = className };
+		public StyleClass ParseStyleClass(string className, string style)
+		{
+			var sc = new StyleClass { Name = className };
 
-            FillStyleClass(sc, className, style);
+			FillStyleClass(sc, className, style);
 
-            return sc;
-        }
+			return sc;
+		}
 
-        private void ProcessStyleSheet(string styleSheetContent)
-        {
-            string content = CleanUp(styleSheetContent);
-            string[] parts = content.Split('}');
+		private void ProcessStyleSheet(string styleSheetContent)
+		{
+			string content = CleanUp(styleSheetContent);
+			string[] parts = content.Split('}');
 
-            foreach (string s in parts)
-            {
-                if (s.IndexOf('{') > -1)
-                {
-                    FillStyleClassFromBlock(s);
-                }
-            }
-        }
+			foreach (string s in parts)
+			{
+				if (s.IndexOf('{') > -1)
+				{
+					FillStyleClassFromBlock(s);
+				}
+			}
+		}
 
-        /// <summary>
-        /// Fills the style class.
-        /// </summary>
-        /// <param name="s">The style block.</param>
-        private void FillStyleClassFromBlock(string s)
-        {
-            string[] parts = s.Split('{');
-            var cleaned = parts[0].Trim();
-            var styleNames = cleaned.Split(',').Select(x => x.Trim());
+		/// <summary>
+		/// Fills the style class.
+		/// </summary>
+		/// <param name="s">The style block.</param>
+		private void FillStyleClassFromBlock(string s)
+		{
+			string[] parts = s.Split('{');
+			var cleaned = parts[0].Trim();
+			var styleNames = cleaned.Split(',').Select(x => x.Trim());
 
-            foreach (var styleName in styleNames)
-            {
-                StyleClass sc;
-                if (_scc.ContainsKey(styleName))
-                {
-                    sc = _scc[styleName];
-                    _scc.Remove(styleName);
-                }
-                else
-                {
-                    sc = new StyleClass();
-                }
+			foreach (var styleName in styleNames)
+			{
+				StyleClass sc;
+				if (_scc.ContainsKey(styleName))
+				{
+					sc = _scc[styleName];
+					_scc.Remove(styleName);
+				}
+				else
+				{
+					sc = new StyleClass();
+				}
 
-                sc.Position = ++styleCount;
+				sc.Position = ++styleCount;
 
-                FillStyleClass(sc, styleName, parts[1]);
+				FillStyleClass(sc, styleName, parts[1]);
 
-                _scc.Add(sc.Name, sc);
-            }
-        }
+				_scc.Add(sc.Name, sc);
+			}
+		}
 
-        /// <summary>
-        /// Fills the style class.
-        /// </summary>
-        /// <param name="sc">The style class.</param>
-        /// <param name="styleName">Name of the style.</param>
-        /// <param name="style">The styles.</param>
-        private void FillStyleClass(StyleClass sc, string styleName, string style)
-        {
-            sc.Name = styleName;
+		/// <summary>
+		/// Fills the style class.
+		/// </summary>
+		/// <param name="sc">The style class.</param>
+		/// <param name="styleName">Name of the style.</param>
+		/// <param name="style">The styles.</param>
+		private void FillStyleClass(StyleClass sc, string styleName, string style)
+		{
+			sc.Name = styleName;
 
-            //string[] atrs = style.Split(';');
-            //string[] atrs = CleanUp(style).Split(';');
-            string[] atrs = FillStyleClassRegex.Split(CleanUp(style));
+			//string[] atrs = style.Split(';');
+			//string[] atrs = CleanUp(style).Split(';');
+			string[] atrs = FillStyleClassRegex.Split(CleanUp(style));
 
-            foreach (string a in atrs)
-            {
-                var attribute = CssAttribute.FromRule(a);
+			foreach (string a in atrs)
+			{
+				var attribute = CssAttribute.FromRule(a);
 
-                if (attribute != null) sc.Attributes[attribute.Style] = attribute;
-            }
-        }
+				if (attribute != null) sc.Attributes[attribute.Style] = attribute;
+			}
+		}
 
 		private static Regex FillStyleClassRegex = new Regex(@"(;)(?=(?:[^""']|[""|'][^""']*"")*$)", RegexOptions.Multiline | RegexOptions.Compiled);
 		private static Regex CssCommentRegex = new Regex(@"(?:/\*(.|[\r\n])*?\*/)|(?:(?<!url\s*\([^)]*)//.*)", RegexOptions.Compiled);
 		private static Regex UnsupportedAtRuleRegex = new Regex(@"(?:@charset [^;]*;)|(?:@(page|font-face)[^{]*{[^}]*})|@import.+?;", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private string CleanUp(string s)
-        {
-            string temp = CssCommentRegex.Replace(s, "");
-            temp = UnsupportedAtRuleRegex.Replace(temp, "");
-            temp = CleanupMediaQueries(temp);
-            temp = temp.Replace("\r", "").Replace("\n", "");
+		private string CleanUp(string s)
+		{
+			string temp = CssCommentRegex.Replace(s, "");
+			temp = UnsupportedAtRuleRegex.Replace(temp, "");
+			temp = CleanupMediaQueries(temp);
+			temp = temp.Replace("\r", "").Replace("\n", "");
 
-            return temp;
-        }
+			return temp;
+		}
 
 		public static Regex SupportedMediaQueriesRegex = new Regex(@"^(?:\s*(?:only\s+)?(?:screen|projection|all),\s*)*(?:(?:only\s+)?(?:screen|projection|all))$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 		private static Regex MediaQueryRegex = new Regex(@"@media\s*(?<query>[^{]*){(?<styles>(?>[^{}]+|{(?<DEPTH>)|}(?<-DEPTH>))*(?(DEPTH)(?!)))}", RegexOptions.Compiled);
 
-        private string CleanupMediaQueries(string s)
-        {
-            string temp = s;
+		private string CleanupMediaQueries(string s)
+		{
+			string temp = s;
 
-            temp = MediaQueryRegex.Replace(temp, m => SupportedMediaQueriesRegex.IsMatch(m.Groups["query"].Value.Trim()) ? m.Groups["styles"].Value.Trim() : string.Empty);
+			temp = MediaQueryRegex.Replace(temp, m => SupportedMediaQueriesRegex.IsMatch(m.Groups["query"].Value.Trim()) ? m.Groups["styles"].Value.Trim() : string.Empty);
 
-            return temp;
-        }
-    }
+			return temp;
+		}
+	}
 }

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -324,7 +324,7 @@ namespace PreMailer.Net
 			{
 				if (style.Key.Attributes != null)
 				{
-					var sortedStyles = style.Value.OrderBy(x => _cssSelectorParser.GetSelectorSpecificity(x.Name)).ToList();
+					var sortedStyles = style.Value.OrderBy(x => _cssSelectorParser.GetSelectorSpecificity(x.Name)).ThenBy(x => x.Position).ToList();
 					var styleAttr = style.Key.Attributes["style"];
 
 					if (styleAttr == null || String.IsNullOrWhiteSpace(styleAttr.Value))

--- a/PreMailer.Net/PreMailer.Net/StyleClass.cs
+++ b/PreMailer.Net/PreMailer.Net/StyleClass.cs
@@ -2,57 +2,57 @@
 using System.Collections.Generic;
 
 namespace PreMailer.Net {
-    public class StyleClass {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StyleClass"/> class.
-        /// </summary>
-        public StyleClass()
-        {
-            Attributes = new Dictionary<string, CssAttribute>(StringComparer.CurrentCultureIgnoreCase);
-        }
+	public class StyleClass {
+		/// <summary>
+		/// Initializes a new instance of the <see cref="StyleClass"/> class.
+		/// </summary>
+		public StyleClass()
+		{
+			Attributes = new Dictionary<string, CssAttribute>(StringComparer.CurrentCultureIgnoreCase);
+		}
 
-        /// <summary>
-        /// Gets or sets the name.
-        /// </summary>
-        /// <value>The name.</value>
-        public string Name { get; set; }
+		/// <summary>
+		/// Gets or sets the name.
+		/// </summary>
+		/// <value>The name.</value>
+		public string Name { get; set; }
 
-        /// <summary>
-        /// The position, relative to other style classes.
-        /// </summary>
-        public int Position { get; set; }
+		/// <summary>
+		/// The position, relative to other style classes.
+		/// </summary>
+		public int Position { get; set; }
 
-        /// <summary>
-        /// Gets or sets the attributes.
-        /// </summary>
-        /// <value>The attributes.</value>
-        public Dictionary<string, CssAttribute> Attributes { get; set; }
+		/// <summary>
+		/// Gets or sets the attributes.
+		/// </summary>
+		/// <value>The attributes.</value>
+		public Dictionary<string, CssAttribute> Attributes { get; set; }
 
-        /// <summary>
-        /// Merges the specified style class, with this instance. Styles on this instance are not overriden by duplicates in the specified styleClass.
-        /// </summary>
-        /// <param name="styleClass">The style class.</param>
-        /// <param name="canOverwrite">if set to <c>true</c> [can overwrite].</param>
-        public void Merge(StyleClass styleClass, bool canOverwrite) {
-            foreach (var item in styleClass.Attributes) {
-                CssAttribute existing;
+		/// <summary>
+		/// Merges the specified style class, with this instance. Styles on this instance are not overriden by duplicates in the specified styleClass.
+		/// </summary>
+		/// <param name="styleClass">The style class.</param>
+		/// <param name="canOverwrite">if set to <c>true</c> [can overwrite].</param>
+		public void Merge(StyleClass styleClass, bool canOverwrite) {
+			foreach (var item in styleClass.Attributes) {
+				CssAttribute existing;
 
-                if (!Attributes.TryGetValue(item.Key, out existing) ||
-                    canOverwrite && (!existing.Important || item.Value.Important))
-                {
-                    Attributes[item.Key] = item.Value;
-                }
-            }
-        }
+				if (!Attributes.TryGetValue(item.Key, out existing) ||
+					canOverwrite && (!existing.Important || item.Value.Important))
+				{
+					Attributes[item.Key] = item.Value;
+				}
+			}
+		}
 
-        /// <summary>
-        /// Returns a <see cref="System.String"/> that represents this instance.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="System.String"/> that represents this instance.
-        /// </returns>
-        public override string ToString() {
-            return string.Join(";", Attributes.Values);
-        }
-    }
+		/// <summary>
+		/// Returns a <see cref="System.String"/> that represents this instance.
+		/// </summary>
+		/// <returns>
+		/// A <see cref="System.String"/> that represents this instance.
+		/// </returns>
+		public override string ToString() {
+			return string.Join(";", Attributes.Values);
+		}
+	}
 }

--- a/PreMailer.Net/PreMailer.Net/StyleClass.cs
+++ b/PreMailer.Net/PreMailer.Net/StyleClass.cs
@@ -6,7 +6,7 @@ namespace PreMailer.Net {
         /// <summary>
         /// Initializes a new instance of the <see cref="StyleClass"/> class.
         /// </summary>
-        public StyleClass() 
+        public StyleClass()
         {
             Attributes = new Dictionary<string, CssAttribute>(StringComparer.CurrentCultureIgnoreCase);
         }
@@ -16,6 +16,11 @@ namespace PreMailer.Net {
         /// </summary>
         /// <value>The name.</value>
         public string Name { get; set; }
+
+        /// <summary>
+        /// The position, relative to other style classes.
+        /// </summary>
+        public int Position { get; set; }
 
         /// <summary>
         /// Gets or sets the attributes.
@@ -31,7 +36,7 @@ namespace PreMailer.Net {
         public void Merge(StyleClass styleClass, bool canOverwrite) {
             foreach (var item in styleClass.Attributes) {
                 CssAttribute existing;
-                
+
                 if (!Attributes.TryGetValue(item.Key, out existing) ||
                     canOverwrite && (!existing.Important || item.Value.Important))
                 {


### PR DESCRIPTION
This is to take into account "where" (relatively speaking) a selector is
found when parsing a css body. Then, this is taken into account during
SortBySpecificity, so if the Specificity score is the same, its position
is then the deciding factor.

This could also fix #53 although I've not tested that.