### PR TITLE
Bump AngleSharp to version 0.9.5

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailer.Net.Tests.csproj
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailer.Net.Tests.csproj
@@ -38,8 +38,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AngleSharp, Version=0.9.4.42449, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
-      <HintPath>..\packages\AngleSharp.0.9.4\lib\net45\AngleSharp.dll</HintPath>
+    <Reference Include="AngleSharp, Version=0.9.5.41771, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
+      <HintPath>..\packages\AngleSharp.0.9.5\lib\net45\AngleSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/PreMailer.Net/PreMailer.Net.Tests/packages.config
+++ b/PreMailer.Net/PreMailer.Net.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AngleSharp" version="0.9.4" targetFramework="net45" />
+  <package id="AngleSharp" version="0.9.5" targetFramework="net45" />
   <package id="coveralls.io" version="1.3.4" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net40" />
   <package id="OpenCover" version="4.6.519" targetFramework="net45" />

--- a/PreMailer.Net/PreMailer.Net/PreMailer.Net.csproj
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.Net.csproj
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AngleSharp, Version=0.9.4.42449, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
-      <HintPath>..\packages\AngleSharp.0.9.4\lib\net45\AngleSharp.dll</HintPath>
+    <Reference Include="AngleSharp, Version=0.9.5.41771, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
+      <HintPath>..\packages\AngleSharp.0.9.5\lib\net45\AngleSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/PreMailer.Net/PreMailer.Net/packages.config
+++ b/PreMailer.Net/PreMailer.Net/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AngleSharp" version="0.9.4" targetFramework="net45" />
+  <package id="AngleSharp" version="0.9.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hey great library but I was having some inconsistent behavior as i was using 0.9.5 of AngleSharp in my project.

All the tests pass and i've made no changes but bumping the version,

Cheers