### PR TITLE
Fix preserving XHTML Strict closing tags by using AngleSharp 0.9.6 ...

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailer.Net.Tests.csproj
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailer.Net.Tests.csproj
@@ -38,9 +38,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AngleSharp, Version=0.9.5.41771, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
-      <HintPath>..\packages\AngleSharp.0.9.5\lib\net45\AngleSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AngleSharp">
+      <HintPath>..\..\..\CapitalID_AngleSharp\AngleSharp.Legacy\bin\Release\AngleSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>

--- a/PreMailer.Net/PreMailer.Net.Tests/packages.config
+++ b/PreMailer.Net/PreMailer.Net.Tests/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AngleSharp" version="0.9.5" targetFramework="net45" />
   <package id="coveralls.io" version="1.3.4" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net40" />
   <package id="OpenCover" version="4.6.519" targetFramework="net45" />

--- a/PreMailer.Net/PreMailer.Net/PreMailer.Net.csproj
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.Net.csproj
@@ -36,9 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AngleSharp, Version=0.9.5.41771, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
-      <HintPath>..\packages\AngleSharp.0.9.5\lib\net45\AngleSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AngleSharp">
+      <HintPath>..\..\..\CapitalID_AngleSharp\AngleSharp.Legacy\bin\Release\AngleSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -69,7 +68,6 @@
     <Compile Include="StyleClassApplier.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="PreMailer.Net.nuspec" />
   </ItemGroup>
   <ItemGroup />

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using AngleSharp;
 using AngleSharp.Dom;
 using AngleSharp.Dom.Html;
 using AngleSharp.Extensions;
@@ -119,9 +120,9 @@ namespace PreMailer.Net
 				}
 			}
 
-			var html = _document.ToHtml();
+            var html = _document.ToHtml(new AutoSelectedMarkupFormatter(_document.Doctype));
 
-			return new InlineResult(html, _warnings);
+            return new InlineResult(html, _warnings);
 		}
 
 		/// <summary>

--- a/PreMailer.Net/PreMailer.Net/packages.config
+++ b/PreMailer.Net/PreMailer.Net/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AngleSharp" version="0.9.5" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
Fixed preserving XHTML Strict closing tags by using AngleSharp 0.9.6 new AutoSelectedMarkupFormatter. This new Formatter uses the DocType to selected the proper Formatter: Html, Xml, or Xhtml(new). 

Merge only when AngleSharp is upgraded to version 0.9.6 or higher!!!
My Pull request is just committed in AngleSharp's develop branch. I'm hoping it gets committed in v0.9.6.   
Commit link: https://github.com/AngleSharp/AngleSharp/commit/f5d8bff0981c764a25718485eb02a509e13510b4

It would be nice if the PreMailer.NET uses this new feature!

Some Unit Tests of the PreMailer project failed. But without my fix the same amount failed so I did not investigate further.

Thanks and Kind regards,

Henry