### PR TITLE
#67: Download bundle link <link href="..." rel="stylesheet">

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/LinkTagCssSourceTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/LinkTagCssSourceTests.cs
@@ -48,6 +48,17 @@ namespace PreMailer.Net.Tests
 		}
 
 		[TestMethod]
+		public void GetCSS_CallsWebDownloader_WithSpecifiedBundle()
+		{
+			string path = "/Content/css?v=7V7TZzP9Wo7LiH9_q-r5mRBdC_N0lA_YJpRL_1V424E1";
+
+			LinkTagCssSource sut = CreateSUT(path: path, link: "<link href=\"{0}\" rel=\"stylesheet\"/>");
+			sut.GetCss();
+
+			_webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.PathAndQuery == path)));
+		}
+
+		[TestMethod]
 		public void GetCSS_AbsoluteUrlInHref_CallsWebDownloader_WithSpecifiedPath()
 		{
 			string path = "http://b.co/a.css";
@@ -58,9 +69,9 @@ namespace PreMailer.Net.Tests
 			_webDownloader.Verify(w => w.DownloadString(new Uri(path)));
 		}
 
-		private LinkTagCssSource CreateSUT(string baseUrl = "http://a.com", string path = "a.css")
+		private LinkTagCssSource CreateSUT(string baseUrl = "http://a.com", string path = "a.css", string link = "<link href=\"{0}\" />")
 		{
-			var node = new HtmlParser().Parse(String.Format("<link href=\"{0}\" />", path));
+			var node = new HtmlParser().Parse(String.Format(link, path));
 			var sut = new LinkTagCssSource(node.Head.FirstElementChild, new Uri(baseUrl));
 
 			return sut;

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -369,6 +369,23 @@ namespace PreMailer.Net.Tests
 		}
 
 		[TestMethod]
+		public void ContainsLinkCssElement_Bundle_DownloadsCss()
+		{
+			var mockDownloader = new Mock<IWebDownloader>();
+			mockDownloader.Setup(d => d.DownloadString(It.IsAny<Uri>())).Returns(".a { display: block; }");
+			WebDownloader.SharedDownloader = mockDownloader.Object;
+
+			Uri baseUri = new Uri("http://a.com");
+			Uri fullUrl = new Uri(baseUri, "/Content/css?v=7V7TZzP9Wo7LiH9_q-r5mRBdC_N0lA_YJpRL_1V424E1");
+			string input = String.Format("<html><head><link href=\"{0}\" rel=\"stylesheet\"></head><body><div id=\"high-imp\" class=\"test\">test</div></body></html>", fullUrl);
+
+			PreMailer sut = new PreMailer(input, baseUri);
+			sut.MoveCssInline();
+
+			mockDownloader.Verify(d => d.DownloadString(fullUrl));
+		}
+
+		[TestMethod]
 		public void ContainsLinkCssElement_NotCssFile_DoNotDownload()
 		{
 			var mockDownloader = new Mock<IWebDownloader>();

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -246,7 +246,9 @@ namespace PreMailer.Net
 
 			return elements.Where(e => e.Attributes
 				.Any(a => a.Name.Equals("href", StringComparison.OrdinalIgnoreCase) &&
-						  a.Value.EndsWith(".css", StringComparison.OrdinalIgnoreCase)));
+						 (a.Value.EndsWith(".css", StringComparison.OrdinalIgnoreCase) || 
+						 (e.Attributes.Any(r => r.Name.Equals("rel", StringComparison.OrdinalIgnoreCase) &&
+												r.Value.Equals("stylesheet", StringComparison.OrdinalIgnoreCase))))));
 		}
 
 


### PR DESCRIPTION
Hello!
I noticed that in last update:

> PreMailer will download and use external style sheets as long as the value of href ends with .css.

It is great feature!
But unfortunately, ASP.NET (MVC) bundle ends with query, and not contains ".css" at all.

Can you extend CssLinkNodes method to return rel="stylesheet" also?

```
return elements.Where(e => e.Attributes
				.Any(a => a.Name.Equals("href", StringComparison.OrdinalIgnoreCase) &&
						 (a.Value.EndsWith(".css", StringComparison.OrdinalIgnoreCase) || 
						 (e.Attributes.Any(r => r.Name.Equals("rel", StringComparison.OrdinalIgnoreCase) &&
												r.Value.Equals("stylesheet", StringComparison.OrdinalIgnoreCase))))));
```