### PR TITLE
Fix for occasional crash due to unsupported URI schemes

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/LinkTagCssSourceTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/LinkTagCssSourceTests.cs
@@ -7,85 +7,85 @@ using AngleSharp.Parser.Html;
 
 namespace PreMailer.Net.Tests
 {
-    [TestClass]
-    public class LinkTagCssSourceTests
-    {
-        private readonly Mock<IWebDownloader> _webDownloader = new Mock<IWebDownloader>();
+	[TestClass]
+	public class LinkTagCssSourceTests
+	{
+		private readonly Mock<IWebDownloader> _webDownloader = new Mock<IWebDownloader>();
 
-        public LinkTagCssSourceTests()
-        {
-            WebDownloader.SharedDownloader = _webDownloader.Object;
-        }
+		public LinkTagCssSourceTests()
+		{
+			WebDownloader.SharedDownloader = _webDownloader.Object;
+		}
 
-        [TestMethod]
-        public void ImplementsInterface()
-        {
-            LinkTagCssSource sut = CreateSUT();
+		[TestMethod]
+		public void ImplementsInterface()
+		{
+			LinkTagCssSource sut = CreateSUT();
 
-            Assert.IsInstanceOfType(sut, typeof(ICssSource));
-        }
+			Assert.IsInstanceOfType(sut, typeof(ICssSource));
+		}
 
-        [TestMethod]
-        public void GetCSS_CallsWebDownloader_WithSpecifiedDomain()
-        {
-            string baseUrl = "http://a.co";
+		[TestMethod]
+		public void GetCSS_CallsWebDownloader_WithSpecifiedDomain()
+		{
+			string baseUrl = "http://a.co";
 
-            LinkTagCssSource sut = CreateSUT(baseUrl: baseUrl);
-            sut.GetCss();
+			LinkTagCssSource sut = CreateSUT(baseUrl: baseUrl);
+			sut.GetCss();
 
-            _webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.Scheme == "http" && u.Host == "a.co")));
-        }
+			_webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.Scheme == "http" && u.Host == "a.co")));
+		}
 
-        [TestMethod]
-        public void GetCSS_CallsWebDownloader_WithSpecifiedPath()
-        {
-            string path = "b.css";
+		[TestMethod]
+		public void GetCSS_CallsWebDownloader_WithSpecifiedPath()
+		{
+			string path = "b.css";
 
-            LinkTagCssSource sut = CreateSUT(path: path);
-            sut.GetCss();
+			LinkTagCssSource sut = CreateSUT(path: path);
+			sut.GetCss();
 
-            _webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.PathAndQuery == "/" + path)));
-        }
+			_webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.PathAndQuery == "/" + path)));
+		}
 
-        [TestMethod]
-        public void GetCSS_CallsWebDownloader_WithSpecifiedBundle()
-        {
-            string path = "/Content/css?v=7V7TZzP9Wo7LiH9_q-r5mRBdC_N0lA_YJpRL_1V424E1";
+		[TestMethod]
+		public void GetCSS_CallsWebDownloader_WithSpecifiedBundle()
+		{
+			string path = "/Content/css?v=7V7TZzP9Wo7LiH9_q-r5mRBdC_N0lA_YJpRL_1V424E1";
 
-            LinkTagCssSource sut = CreateSUT(path: path, link: "<link href=\"{0}\" rel=\"stylesheet\"/>");
-            sut.GetCss();
+			LinkTagCssSource sut = CreateSUT(path: path, link: "<link href=\"{0}\" rel=\"stylesheet\"/>");
+			sut.GetCss();
 
-            _webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.PathAndQuery == path)));
-        }
+			_webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.PathAndQuery == path)));
+		}
 
-        [TestMethod]
-        public void GetCSS_AbsoluteUrlInHref_CallsWebDownloader_WithSpecifiedPath()
-        {
-            string path = "http://b.co/a.css";
+		[TestMethod]
+		public void GetCSS_AbsoluteUrlInHref_CallsWebDownloader_WithSpecifiedPath()
+		{
+			string path = "http://b.co/a.css";
 
-            LinkTagCssSource sut = CreateSUT(path: path);
-            sut.GetCss();
+			LinkTagCssSource sut = CreateSUT(path: path);
+			sut.GetCss();
 
-            _webDownloader.Verify(w => w.DownloadString(new Uri(path)));
-        }
+			_webDownloader.Verify(w => w.DownloadString(new Uri(path)));
+		}
 
-        [TestMethod]
-        public void GetCSS_DoesNotCallWebDownloader_WhenSchemeNotSupported()
-        {
-            string path = "chrome-extension://fcdjadjbdihbaodagojiomdljhjhjfho/css/atd.css";
+		[TestMethod]
+		public void GetCSS_DoesNotCallWebDownloader_WhenSchemeNotSupported()
+		{
+			string path = "chrome-extension://fcdjadjbdihbaodagojiomdljhjhjfho/css/atd.css";
 
-            LinkTagCssSource sut = CreateSUT(path: path);
-            sut.GetCss();
+			LinkTagCssSource sut = CreateSUT(path: path);
+			sut.GetCss();
 
-            _webDownloader.Verify(w => w.DownloadString(new Uri(path)), Times.Never);
-        }
+			_webDownloader.Verify(w => w.DownloadString(new Uri(path)), Times.Never);
+		}
 
-        private LinkTagCssSource CreateSUT(string baseUrl = "http://a.com", string path = "a.css", string link = "<link href=\"{0}\" />")
-        {
-            var node = new HtmlParser().Parse(String.Format(link, path));
-            var sut = new LinkTagCssSource(node.Head.FirstElementChild, new Uri(baseUrl));
+		private LinkTagCssSource CreateSUT(string baseUrl = "http://a.com", string path = "a.css", string link = "<link href=\"{0}\" />")
+		{
+			var node = new HtmlParser().Parse(String.Format(link, path));
+			var sut = new LinkTagCssSource(node.Head.FirstElementChild, new Uri(baseUrl));
 
-            return sut;
-        }
-    }
+			return sut;
+		}
+	}
 }

--- a/PreMailer.Net/PreMailer.Net.Tests/LinkTagCssSourceTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/LinkTagCssSourceTests.cs
@@ -7,74 +7,85 @@ using AngleSharp.Parser.Html;
 
 namespace PreMailer.Net.Tests
 {
-	[TestClass]
-	public class LinkTagCssSourceTests
-	{
-		private readonly Mock<IWebDownloader> _webDownloader = new Mock<IWebDownloader>();
+    [TestClass]
+    public class LinkTagCssSourceTests
+    {
+        private readonly Mock<IWebDownloader> _webDownloader = new Mock<IWebDownloader>();
 
-		public LinkTagCssSourceTests()
-		{
-			WebDownloader.SharedDownloader = _webDownloader.Object;
-		}
+        public LinkTagCssSourceTests()
+        {
+            WebDownloader.SharedDownloader = _webDownloader.Object;
+        }
 
-		[TestMethod]
-		public void ImplementsInterface()
-		{
-			LinkTagCssSource sut = CreateSUT();
+        [TestMethod]
+        public void ImplementsInterface()
+        {
+            LinkTagCssSource sut = CreateSUT();
 
-			Assert.IsInstanceOfType(sut, typeof(ICssSource));
-		}
+            Assert.IsInstanceOfType(sut, typeof(ICssSource));
+        }
 
-		[TestMethod]
-		public void GetCSS_CallsWebDownloader_WithSpecifiedDomain()
-		{
-			string baseUrl = "http://a.co";
+        [TestMethod]
+        public void GetCSS_CallsWebDownloader_WithSpecifiedDomain()
+        {
+            string baseUrl = "http://a.co";
 
-			LinkTagCssSource sut = CreateSUT(baseUrl: baseUrl);
-			sut.GetCss();
+            LinkTagCssSource sut = CreateSUT(baseUrl: baseUrl);
+            sut.GetCss();
 
-			_webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.Scheme == "http" && u.Host == "a.co")));
-		}
+            _webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.Scheme == "http" && u.Host == "a.co")));
+        }
 
-		[TestMethod]
-		public void GetCSS_CallsWebDownloader_WithSpecifiedPath()
-		{
-			string path = "b.css";
+        [TestMethod]
+        public void GetCSS_CallsWebDownloader_WithSpecifiedPath()
+        {
+            string path = "b.css";
 
-			LinkTagCssSource sut = CreateSUT(path: path);
-			sut.GetCss();
+            LinkTagCssSource sut = CreateSUT(path: path);
+            sut.GetCss();
 
-			_webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.PathAndQuery == "/" + path)));
-		}
+            _webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.PathAndQuery == "/" + path)));
+        }
 
-		[TestMethod]
-		public void GetCSS_CallsWebDownloader_WithSpecifiedBundle()
-		{
-			string path = "/Content/css?v=7V7TZzP9Wo7LiH9_q-r5mRBdC_N0lA_YJpRL_1V424E1";
+        [TestMethod]
+        public void GetCSS_CallsWebDownloader_WithSpecifiedBundle()
+        {
+            string path = "/Content/css?v=7V7TZzP9Wo7LiH9_q-r5mRBdC_N0lA_YJpRL_1V424E1";
 
-			LinkTagCssSource sut = CreateSUT(path: path, link: "<link href=\"{0}\" rel=\"stylesheet\"/>");
-			sut.GetCss();
+            LinkTagCssSource sut = CreateSUT(path: path, link: "<link href=\"{0}\" rel=\"stylesheet\"/>");
+            sut.GetCss();
 
-			_webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.PathAndQuery == path)));
-		}
+            _webDownloader.Verify(w => w.DownloadString(It.Is<Uri>(u => u.PathAndQuery == path)));
+        }
 
-		[TestMethod]
-		public void GetCSS_AbsoluteUrlInHref_CallsWebDownloader_WithSpecifiedPath()
-		{
-			string path = "http://b.co/a.css";
+        [TestMethod]
+        public void GetCSS_AbsoluteUrlInHref_CallsWebDownloader_WithSpecifiedPath()
+        {
+            string path = "http://b.co/a.css";
 
-			LinkTagCssSource sut = CreateSUT(path: path);
-			sut.GetCss();
+            LinkTagCssSource sut = CreateSUT(path: path);
+            sut.GetCss();
 
-			_webDownloader.Verify(w => w.DownloadString(new Uri(path)));
-		}
+            _webDownloader.Verify(w => w.DownloadString(new Uri(path)));
+        }
 
-		private LinkTagCssSource CreateSUT(string baseUrl = "http://a.com", string path = "a.css", string link = "<link href=\"{0}\" />")
-		{
-			var node = new HtmlParser().Parse(String.Format(link, path));
-			var sut = new LinkTagCssSource(node.Head.FirstElementChild, new Uri(baseUrl));
+        [TestMethod]
+        public void GetCSS_DoesNotCallWebDownloader_WhenSchemeNotSupported()
+        {
+            string path = "chrome-extension://fcdjadjbdihbaodagojiomdljhjhjfho/css/atd.css";
 
-			return sut;
-		}
-	}
+            LinkTagCssSource sut = CreateSUT(path: path);
+            sut.GetCss();
+
+            _webDownloader.Verify(w => w.DownloadString(new Uri(path)), Times.Never);
+        }
+
+        private LinkTagCssSource CreateSUT(string baseUrl = "http://a.com", string path = "a.css", string link = "<link href=\"{0}\" />")
+        {
+            var node = new HtmlParser().Parse(String.Format(link, path));
+            var sut = new LinkTagCssSource(node.Head.FirstElementChild, new Uri(baseUrl));
+
+            return sut;
+        }
+    }
 }

--- a/PreMailer.Net/PreMailer.Net/Sources/LinkTagCssSource.cs
+++ b/PreMailer.Net/PreMailer.Net/Sources/LinkTagCssSource.cs
@@ -5,43 +5,43 @@ using PreMailer.Net.Downloaders;
 
 namespace PreMailer.Net.Sources
 {
-    public class LinkTagCssSource : ICssSource
-    {
-        private readonly Uri _downloadUri;
-        private string _cssContents;
+	public class LinkTagCssSource : ICssSource
+	{
+		private readonly Uri _downloadUri;
+		private string _cssContents;
 
-        public LinkTagCssSource(IElement node, Uri baseUri)
-        {
-            // There must be an href
-            var href = node.Attributes.First(a => a.Name.Equals("href", StringComparison.OrdinalIgnoreCase)).Value;
+		public LinkTagCssSource(IElement node, Uri baseUri)
+		{
+			// There must be an href
+			var href = node.Attributes.First(a => a.Name.Equals("href", StringComparison.OrdinalIgnoreCase)).Value;
 
-            if (Uri.IsWellFormedUriString(href, UriKind.Relative) && baseUri != null)
-            {
-                _downloadUri = new Uri(baseUri, href);
-            }
-            else
-            {
-                // Assume absolute
-                _downloadUri = new Uri(href);
-            }
-        }
+			if (Uri.IsWellFormedUriString(href, UriKind.Relative) && baseUri != null)
+			{
+				_downloadUri = new Uri(baseUri, href);
+			}
+			else
+			{
+				// Assume absolute
+				_downloadUri = new Uri(href);
+			}
+		}
 
-        public string GetCss()
-        {
-            if (IsSupported(_downloadUri.Scheme))
-            {
-                return _cssContents ?? (_cssContents = WebDownloader.SharedDownloader.DownloadString(_downloadUri));
-            }
-            return string.Empty;
-        }
+		public string GetCss()
+		{
+			if (IsSupported(_downloadUri.Scheme))
+			{
+				return _cssContents ?? (_cssContents = WebDownloader.SharedDownloader.DownloadString(_downloadUri));
+			}
+			return string.Empty;
+		}
 
-        private bool IsSupported(string scheme)
-        {
-            return
-                scheme == Uri.UriSchemeHttp ||
-                scheme == Uri.UriSchemeHttps ||
-                scheme == Uri.UriSchemeFtp ||
-                scheme == Uri.UriSchemeFile;
-        }
-    }
+		private bool IsSupported(string scheme)
+		{
+			return
+				scheme == Uri.UriSchemeHttp ||
+				scheme == Uri.UriSchemeHttps ||
+				scheme == Uri.UriSchemeFtp ||
+				scheme == Uri.UriSchemeFile;
+		}
+	}
 }

--- a/PreMailer.Net/PreMailer.Net/Sources/LinkTagCssSource.cs
+++ b/PreMailer.Net/PreMailer.Net/Sources/LinkTagCssSource.cs
@@ -5,30 +5,43 @@ using PreMailer.Net.Downloaders;
 
 namespace PreMailer.Net.Sources
 {
-	public class LinkTagCssSource : ICssSource
-	{
-		private readonly Uri _downloadUri;
-		private string _cssContents;
+    public class LinkTagCssSource : ICssSource
+    {
+        private readonly Uri _downloadUri;
+        private string _cssContents;
 
-		public LinkTagCssSource(IElement node, Uri baseUri)
-		{
-			// There must be an href
-			var href = node.Attributes.First(a => a.Name.Equals("href", StringComparison.OrdinalIgnoreCase)).Value;
+        public LinkTagCssSource(IElement node, Uri baseUri)
+        {
+            // There must be an href
+            var href = node.Attributes.First(a => a.Name.Equals("href", StringComparison.OrdinalIgnoreCase)).Value;
 
-			if (Uri.IsWellFormedUriString(href, UriKind.Relative) && baseUri != null)
-			{
-				_downloadUri = new Uri(baseUri, href);
-			}
-			else
-			{
-				// Assume absolute
-				_downloadUri = new Uri(href);
-			}
-		}
+            if (Uri.IsWellFormedUriString(href, UriKind.Relative) && baseUri != null)
+            {
+                _downloadUri = new Uri(baseUri, href);
+            }
+            else
+            {
+                // Assume absolute
+                _downloadUri = new Uri(href);
+            }
+        }
 
-		public string GetCss()
-		{
-			return _cssContents ?? (_cssContents = WebDownloader.SharedDownloader.DownloadString(_downloadUri));
-		}
-	}
+        public string GetCss()
+        {
+            if (IsSupported(_downloadUri.Scheme))
+            {
+                return _cssContents ?? (_cssContents = WebDownloader.SharedDownloader.DownloadString(_downloadUri));
+            }
+            return string.Empty;
+        }
+
+        private bool IsSupported(string scheme)
+        {
+            return
+                scheme == Uri.UriSchemeHttp ||
+                scheme == Uri.UriSchemeHttps ||
+                scheme == Uri.UriSchemeFtp ||
+                scheme == Uri.UriSchemeFile;
+        }
+    }
 }


### PR DESCRIPTION
We have recently begun using Premailer in a high traffic environment (and we love it). We've run into a handful of users who have inadvertently injected client-side CSS links, and currently Premailer throws an exception when it tries to inline it. That's because underneath, it uses WebClient, which only supports four URI schemes.

Here's a suggested fix which only attempts to download from the four supported schemes, including a supporting test. Would love any feedback! Thanks.