### PR TITLE
Added option to preserve mediaqueries without needing a separate style tag

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -130,11 +130,19 @@ namespace PreMailer.Net.Tests
 		[TestMethod]
 		public void MoveCssInline_KeepStyleElementsIgnoreElementsMatchesStyleElement_DoesntRemoveScriptTag()
 		{
-			string input = "<html><head><style id=\"ignore\" type=\"text/css\">li:before { width: 42px; }</style></head><body><div class=\"target\">test</div></body></html>";
 
-			var premailedOutput = PreMailer.MoveCssInline(input, removeStyleElements: false, ignoreElements: "#ignore");
+			var premailedOutput = PreMailer.MoveCssInline(input, removeStyleElements: true, ignoreElements: "#ignore");
 
 			Assert.IsTrue(premailedOutput.Html.Contains("<style id=\"ignore\" type=\"text/css\">"));
+		}
+
+		[TestMethod]
+		public void MoveCssInline_KeepMediaQueries_InsertsStyleTag()
+			{
+
+			var premailedOutput = PreMailer.MoveCssInline(input, removeStyleElements: true, keepMediaQueries: true);
+
+			Assert.IsTrue(premailedOutput.Html.Contains("<style>@media only screen and (max-width:620px) { div { width: 100% } }</style>"));
 		}
 
 		[TestMethod]

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -130,6 +130,7 @@ namespace PreMailer.Net.Tests
 		[TestMethod]
 		public void MoveCssInline_KeepStyleElementsIgnoreElementsMatchesStyleElement_DoesntRemoveScriptTag()
 		{
+			string input = "<html><head><style id=\"ignore\" type=\"text/css\">li { width: 42px; } </style></head><body><div class=\"target\">test</div></body></html>";
 
 			var premailedOutput = PreMailer.MoveCssInline(input, removeStyleElements: true, ignoreElements: "#ignore");
 
@@ -139,6 +140,7 @@ namespace PreMailer.Net.Tests
 		[TestMethod]
 		public void MoveCssInline_KeepMediaQueries_InsertsStyleTag()
 			{
+			string input = "<html><head><style type=\"text/css\">li:before { width: 42px; } @media only screen and (max-width:620px) { div { width: 100% } }</style></head><body><div class=\"target\">test</div></body></html>";
 
 			var premailedOutput = PreMailer.MoveCssInline(input, removeStyleElements: true, keepMediaQueries: true);
 

--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -8,6 +8,7 @@ namespace PreMailer.Net
 	{
 		private readonly List<string> _styleSheets;
 		private SortedList<string, StyleClass> _scc;
+		private IList<string> _mqs;
 		private int styleCount = 0;
 
 		public SortedList<string, StyleClass> Styles
@@ -16,10 +17,17 @@ namespace PreMailer.Net
 			set { _scc = value; }
 		}
 
+		public IList<string> MediaQueries
+		{
+			get { return _mqs; }
+			set { _mqs = value; }
+		}
+
 		public CssParser()
 		{
 			_styleSheets = new List<string>();
 			_scc = new SortedList<string, StyleClass>();
+			_mqs = new List<string>();
 		}
 
 		public void AddStyleSheet(string styleSheetContent)
@@ -123,14 +131,21 @@ namespace PreMailer.Net
 			return temp;
 		}
 
-		public static Regex SupportedMediaQueriesRegex = new Regex(@"^(?:\s*(?:only\s+)?(?:screen|projection|all),\s*)*(?:(?:only\s+)?(?:screen|projection|all))$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+		public static Regex SupportedMediaAttributesRegex = new Regex(@"^(?:\s*(?:only\s+)?(?:screen|projection|all),\s*)*(?:(?:only\s+)?(?:screen|projection|all))$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 		private static Regex MediaQueryRegex = new Regex(@"@media\s*(?<query>[^{]*){(?<styles>(?>[^{}]+|{(?<DEPTH>)|}(?<-DEPTH>))*(?(DEPTH)(?!)))}", RegexOptions.Compiled);
 
 		private string CleanupMediaQueries(string s)
 		{
 			string temp = s;
 
-			temp = MediaQueryRegex.Replace(temp, m => SupportedMediaQueriesRegex.IsMatch(m.Groups["query"].Value.Trim()) ? m.Groups["styles"].Value.Trim() : string.Empty);
+			var mqMatch = MediaQueryRegex.Match(temp);
+			while (mqMatch.Success)
+			{
+				_mqs.Add(mqMatch.Value);
+				mqMatch = mqMatch.NextMatch();
+			}
+
+			temp = MediaQueryRegex.Replace(temp, string.Empty);
 
 			return temp;
 		}


### PR DESCRIPTION
The current approach requires media queries are kept in a separate style
tag, however this is not possible to do with many frameworks or CSS
preprocessors.

I've added a new option for keeping media queries that results ina new
style tag being added at the top of the body (important for many
clients) with the extracted mediaqueries. This only runs if
removeStyleElements is true to avoid duplication.

Thereis one breaking changes with how mediaqueries are currently
handled:

Allowed media queries in stylesheets are no longer parsed. Media query
support in emails is poor anyway so screen only really shouldn't be
used. If it is used it is likely to be explicitly to target certain
clients that only read media queries (this does not affect media
attributes)

I believe this change is worthwhile for the benefit gained in allowing
Premailer.Net to work with various preprocessors and is a minor edge
case in general if you are designing for email properly. Updating CSS to
avoid these changes will likely actually improve email design support.