### PR TITLE
Make the project compatible with .NET Core RC4

### DIFF
--- a/PreMailer.Net-dotnet/PreMailer.Net.csproj
+++ b/PreMailer.Net-dotnet/PreMailer.Net.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <Version>1.5.6</Version>
+    <Authors>Martin H. Normark</Authors>
+    <Description>
+        PreMailer.Net is a C# utility for moving CSS to inline style attributes, to gain maximum E-mail client compatibility.
+    </Description>
+    <Copyright>Copyright 2016</Copyright>
+    <PackageLicenseUrl>https://github.com/milkshakesoftware/PreMailer.Net/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/milkshakesoftware/PreMailer.Net</PackageProjectUrl>
+    <PackageIconUrl>https://github.com/milkshakesoftware/PreMailer.Net/raw/master/icon.png</PackageIconUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageReleaseNotes>
+        Fix missing method exception https://github.com/milkshakesoftware/PreMailer.Net/issues/130
+    </PackageReleaseNotes>
+    <PackageTags>email css newsletter html</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="0.9.9" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
+  </ItemGroup>
+  
+  
+  <ItemGroup>  
+    <Compile
+      Include="../PreMailer.Net/PreMailer.Net/**/*.cs"
+      Exclude="**/AssemblyInfo.cs" />
+  </ItemGroup>
+</Project>

--- a/PreMailer.Net-dotnet/PreMailer.Net.nuspec
+++ b/PreMailer.Net-dotnet/PreMailer.Net.nuspec
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<package >
+	<metadata>
+		<id>PreMailer.Net</id>
+
+	</metadata>
+</package>

--- a/PreMailer.Net-dotnet/nuget.bat
+++ b/PreMailer.Net-dotnet/nuget.bat
@@ -1,0 +1,12 @@
+:: Need [.NET Core SDK 1.0 rc4](https://github.com/dotnet/core/blob/master/release-notes/rc4-download.md)
+@echo off
+
+echo.
+echo Restoring project...
+
+dotnet restore
+
+echo.
+echo Creating NuGet Package...
+
+dotnet pack --configuration Release --include-symbols

--- a/PreMailer.Net/PreMailer.Net/Downloaders/WebDownloader.cs
+++ b/PreMailer.Net/PreMailer.Net/Downloaders/WebDownloader.cs
@@ -28,7 +28,7 @@ namespace PreMailer.Net.Downloaders
 		public string DownloadString(Uri uri)
 		{
 			var request = WebRequest.Create(uri);
-			using (var response = request.GetResponse())
+			using (var response = request.GetResponseAsync().Result)
 			using (var stream = response.GetResponseStream())
 			using (var reader = new StreamReader(stream))
 			{

--- a/PreMailer.Net/PreMailer.Net/Sources/LinkTagCssSource.cs
+++ b/PreMailer.Net/PreMailer.Net/Sources/LinkTagCssSource.cs
@@ -38,10 +38,10 @@ namespace PreMailer.Net.Sources
 		private bool IsSupported(string scheme)
 		{
 			return
-				scheme == Uri.UriSchemeHttp ||
-				scheme == Uri.UriSchemeHttps ||
-				scheme == Uri.UriSchemeFtp ||
-				scheme == Uri.UriSchemeFile;
+				scheme == "http" ||
+				scheme == "https" ||
+				scheme == "ftp" ||
+				scheme == "file";
 		}
 	}
 }


### PR DESCRIPTION
I propose this merge request to support .NET Core with RC4 tooling.

Compared to pull request #122, the suggested modifications are very minor:
- Only five lines had to be changed in the source code in order to comply with .NET Core APIs. These changes are retrocompatible with standard .NET Framework.
- The dotnet core publish process is in a new directory `PreMailer.Net-dotnet`.

Install [.NET Core SDK 1.0 rc4](https://github.com/dotnet/core/blob/master/release-notes/rc4-download.md), execute `nuget.bat` inside `PreMailer.Net-dotnet`, and that should be it.

I stay available if you need any help.
