### PR TITLE
[BUG] Problem when Style tag contain html comment tags

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -455,5 +455,30 @@ namespace PreMailer.Net.Tests
 
 			Assert.IsTrue(premailedOutput.Html.StartsWith("<html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:v=\"urn:schemas-microsoft-com:vml\" xmlns:o=\"urn:schemas-microsoft-com:office:office\">"));
 		}
-	}
+
+        [TestMethod]
+        public void MoveCSSInline_MergingTwoValidCssRules()
+        {
+            string input = @"<html>
+<head>
+<style><!--
+/* Font Definitions */
+p.MsoNormal
+  {margin:0cm;}
+p
+  {mso-style-priority:99;}
+--></style>
+</head>
+<body>
+<div>
+<p class=""MsoNormal""><span style=""font-family:Source Sans Pro,serif"">Line1</span></p>
+</div>
+</body>
+</html>";
+
+            var premailedOutput = PreMailer.MoveCssInline(input, true, null, null);
+
+            Assert.IsTrue(premailedOutput.Html.Contains("style=\"mso-style-priority: 99;margin: 0cm\""));
+        }
+    }
 }

--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -119,7 +119,7 @@ namespace PreMailer.Net
 			temp = UnsupportedAtRuleRegex.Replace(temp, "");
 			temp = CleanupMediaQueries(temp);
 			temp = temp.Replace("\r", "").Replace("\n", "");
-
+            temp = temp.Replace("<!--", "").Replace("-->", "");
 			return temp;
 		}
 


### PR DESCRIPTION
### Description

- When received e-mail from Microsoft Outlook on Desktop, the e-mail comes with style tag having an HTML comment Block in.
- On browsers, this comment will be ignored and CSS was processed.
- When processed by PreMailer, the first CSS will be ignored because it will be merged with comment text.

### Proposal

- Remove the HTML block comment chars of CSS styles.
