### PR TITLE
Support for .NET Framework 4.5 and up, besides .NET Core 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ build/
 [Bb]in/
 [Oo]bj/
 
+# Visual Studio cache/options directory
+.vs/
+
 !Libraries/Redis/bin/
 !Libraries/Mongo/bin/
 

--- a/PreMailer.Net/.gitignore
+++ b/PreMailer.Net/.gitignore
@@ -16,6 +16,7 @@ x64/
 build/
 [Bb]in/
 [Oo]bj/
+.vs/
 
 !Libraries/Redis/bin/
 !Libraries/Mongo/bin/

--- a/PreMailer.Net/PreMailer.Net/PreMailer.Net.csproj
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.Net.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>2.0.0</Version>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <Version>2.0.1</Version>
     <Authors>Martin H. Normark</Authors>
     <Description>
         PreMailer.Net is a C# utility for moving CSS to inline style attributes, to gain maximum E-mail client compatibility.
@@ -13,14 +13,13 @@
     <PackageIconUrl>https://github.com/milkshakesoftware/PreMailer.Net/raw/master/icon.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>
-        Support for .NET Core https://github.com/milkshakesoftware/PreMailer.Net/pull/141
-		Fix: Duplicated style properties added with different values https://github.com/milkshakesoftware/PreMailer.Net/pull/139
+        Support for .NET Framework 4.5 and up, besides .NET Core 2
     </PackageReleaseNotes>
     <PackageTags>email css newsletter html</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.9.9" />
+    <PackageReference Include="AngleSharp" Version="0.9.11" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
PreMailer is a perfect complement for [MailMergeLib](https://github.com/axuno/MailMergeLib), which supports .Net Core and .Net Framework 4.5+. Currently the nuget package only includes .Net Core support, so we'd be more than happy if .Net Framework could be added, as it works perfectly here as well.