### PR TITLE
Handle bad external css links

### DIFF
--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -175,7 +175,14 @@ namespace PreMailer.Net
 
 			foreach (var styleSource in cssSources)
 			{
-				styleBlocks.Add(styleSource.GetCss());
+                try
+                {
+                    styleBlocks.Add(styleSource.GetCss());
+                }
+                catch (System.Net.WebException e)
+                {
+                    _warnings.Add(e.Message);
+                }
 			}
 
 			return styleBlocks;

--- a/PreMailer.Net/PreMailer.Net/Sources/LinkTagCssSource.cs
+++ b/PreMailer.Net/PreMailer.Net/Sources/LinkTagCssSource.cs
@@ -30,8 +30,14 @@ namespace PreMailer.Net.Sources
 		{
 			if (IsSupported(_downloadUri.Scheme))
 			{
-				return _cssContents ?? (_cssContents = WebDownloader.SharedDownloader.DownloadString(_downloadUri));
-			}
+                try
+                {
+                    return _cssContents ?? (_cssContents = WebDownloader.SharedDownloader.DownloadString(_downloadUri));
+                } catch (System.Net.WebException)
+                {
+                    throw new System.Net.WebException(string.Format("PreMailer.Net is unable to fetch the requested URL: {0}", _downloadUri));
+                }
+            }
 			return string.Empty;
 		}
 


### PR DESCRIPTION
Catch webexception and add to InlineResult warnings