### PR TITLE
Add support on fetching Uri with local filepath

### DIFF
--- a/PreMailer.Net/PreMailer.Net/Downloaders/WebDownloader.cs
+++ b/PreMailer.Net/PreMailer.Net/Downloaders/WebDownloader.cs
@@ -29,14 +29,32 @@ namespace PreMailer.Net.Downloaders
 		public string DownloadString(Uri uri)
 		{
 			var request = WebRequest.Create(uri);
-			using (var response = (HttpWebResponse)request.GetResponse())
+			using (var response = request.GetResponse())
 			{
-				var charset = response.CharacterSet;
-				var encoding = Encoding.GetEncoding(charset);
-				using (var stream = response.GetResponseStream())
-				using (var reader = new StreamReader(stream, encoding))
+				switch (response)
 				{
-					return reader.ReadToEnd();
+					case HttpWebResponse httpWebResponse:
+					{
+						var charset = httpWebResponse.CharacterSet;
+						var encoding = Encoding.GetEncoding(charset);
+						using (var stream = httpWebResponse.GetResponseStream())
+						using (var reader = new StreamReader(stream, encoding))
+						{
+							return reader.ReadToEnd();
+						}
+					}
+
+					case FileWebResponse fileWebResponse:
+					{
+						using (var stream = fileWebResponse.GetResponseStream())
+						using (var reader = new StreamReader(stream))
+						{
+							return reader.ReadToEnd();
+						}
+					}
+
+					default:
+						throw new NotSupportedException($"The Uri type is giving a response in unsupported type '{response.GetType()}'.");
 				}
 			}
 		}


### PR DESCRIPTION
Add support on fetching Uri with local filepath like "file:///C:/website/style.css"

It's required when we optimize the performance by fetching the local resource internally instead of making external web request towards internal resource.
e.g. As I know the css is actually inside the local storage, it make sense to just make a fast local fetch ("file:///C:/website/style.css") instead of external web request ("https://www.mysite.com/style.css")

So I can now initialize a PreMailer instance with BaseUri `"file:///" + new Uri(System.Web.Hosting.HostingEnvironment.MapPath("~/"), UriKind.Absolute)`

It's how I boost the performance for my client, just share my code here.