### PR TITLE
Fix: Keep css attributes in logical order (#53)

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/CssParserTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssParserTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+using System.Linq;
+using Xunit;
 
 namespace PreMailer.Net.Tests
 {
@@ -170,6 +171,26 @@ namespace PreMailer.Net.Tests
 			Assert.Equal(4, parser.Styles.Values[1].Position);
 			Assert.Equal(3, parser.Styles.Values[2].Position);
         }
+
+		[Fact]
+		public void AddStylesheet_ShouldKeepTheRightOrderOfCssAttributes()
+		{
+			var stylesheet1 = @"
+				.my-div { background-color: blue; }
+				.my-div { background: red; }
+				.my-div { background-color: green; }
+			";
+			var parser = new CssParser();
+
+			parser.AddStyleSheet(stylesheet1);
+
+			Assert.Single(parser.Styles);
+
+			var attributes = parser.Styles.First().Value.Attributes.ToArray();
+
+			Assert.True(attributes[0] is {Key: "background", Value: {Value: "red"}});
+			Assert.True(attributes[1] is {Key: "background-color", Value: {Value: "green"}});
+		}
 
         [Fact]
         public void AddStylesheet_ContainsSingleQuotes_ShouldParseStylesheet()

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -144,7 +144,7 @@ namespace PreMailer.Net.Tests
 
 			var premailedOutput = PreMailer.MoveCssInline(input);
 
-			Assert.True(premailedOutput.Html.Contains("<p style=\"font-size: 11px;line-height: 16px\"></p>"));
+			Assert.True(premailedOutput.Html.Contains("<p style=\"line-height: 16px;font-size: 11px\"></p>"));
 		}
 
 		[Fact]

--- a/PreMailer.Net/PreMailer.Net/CssAttributeCollection.cs
+++ b/PreMailer.Net/PreMailer.Net/CssAttributeCollection.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PreMailer.Net {
+	public class CssAttributeCollection : IDictionary<string, CssAttribute> {
+		private readonly IDictionary<string, CssValue> _attributes;
+		private int _currentPosition;
+
+		public CssAttributeCollection()
+		{
+			_attributes = new Dictionary<string, CssValue>(StringComparer.CurrentCultureIgnoreCase);
+			_currentPosition = 0;
+		}
+
+		/// <summary>
+		/// Add a CssAttribute and set it's position to overwrite all previous CssAttributes in the same Collection.
+		/// </summary>
+		public void Add(KeyValuePair<string, CssAttribute> item)
+		{
+			_attributes.Add(item.Key, new CssValue(position: ++_currentPosition, attribute: item.Value));
+		}
+
+		/// <summary>
+		/// Add a CssAttribute and set it's position to overwrite all previous CssAttributes in the same Collection.
+		/// </summary>
+		public void Add(string key, CssAttribute value)
+		{
+			_attributes.Add(key, new CssValue(position: ++_currentPosition, attribute: value));
+		}
+
+		/// <summary>
+		/// Add or Update a CssAttribute without changing it's position in the case of an update.
+		/// </summary>
+		public CssAttribute this[string key] {
+			get => _attributes[key].Attribute;
+			set {
+				if (_attributes.TryGetValue(key, out var existing)) {
+					_attributes[key] = new CssValue(position: existing.Position, attribute: value);
+				}
+				else {
+					_attributes[key] = new CssValue(position: ++_currentPosition, attribute: value);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Add or Update a CssAttribute and set it's position to overwrite all previous CssAttributes in the same Collection.
+		/// </summary>
+		public void Merge(CssAttribute attribute)
+		{
+			var key = attribute.Style;
+			var value = attribute;
+
+			_attributes[key] = new CssValue(position: ++_currentPosition, attribute: value);
+		}
+
+		/// <summary>
+		/// Copy the entries of this Collection, ordered by position, to the destination Array.
+		/// </summary>
+		public void CopyTo(KeyValuePair<string, CssAttribute>[] array, int arrayIndex)
+		{
+			var arr = _attributes.OrderBy(_ => _.Value.Position).Select(_ => new KeyValuePair<string, CssAttribute>(_.Key, _.Value.Attribute)).ToArray();
+			Array.Copy(arr, 0, array, arrayIndex, arr.Length);
+		}
+
+		/// <summary>
+		/// Gets an Enumerator of the attributes in this collection, ordered by position.
+		/// </summary>
+		public IEnumerator<KeyValuePair<string, CssAttribute>> GetEnumerator()
+		{
+			return _attributes
+				.OrderBy(_ => _.Value.Position)
+				.Select(pair => new KeyValuePair<string, CssAttribute>(pair.Key, pair.Value.Attribute)).GetEnumerator();
+		}
+
+		/// <summary>
+		/// Gets an Enumerator of the attributes in this collection, ordered by position.
+		/// </summary>
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+
+		/// <summary>
+		/// Gets all Keys in this Collection ordered by position.
+		/// </summary>
+		public ICollection<string> Keys => _attributes.OrderBy(_ => _.Value.Position).Select(_ => _.Key).ToList();
+
+		/// <summary>
+		/// Gets all Values in this Collection ordered by position.
+		/// </summary>
+		public ICollection<CssAttribute> Values => _attributes.Values.OrderBy(_ => _.Position).Select(_ => _.Attribute).ToList();
+
+		/// <inheritdoc />
+		public int Count => _attributes.Count;
+
+		/// <inheritdoc />
+		public bool IsReadOnly => _attributes.IsReadOnly;
+
+		/// <inheritdoc />
+		public bool TryGetValue(string key, out CssAttribute value)
+		{
+			if (_attributes.TryGetValue(key, out var data)) {
+				value = data.Attribute;
+				return true;
+			}
+
+			value = default;
+			return false;
+		}
+
+		/// <inheritdoc />
+		public bool Contains(KeyValuePair<string, CssAttribute> item)
+		{
+			return _attributes.TryGetValue(item.Key, out var value) && value.Attribute == item.Value;
+		}
+
+		/// <inheritdoc />
+		public bool ContainsKey(string key)
+		{
+			return _attributes.ContainsKey(key);
+		}
+
+		/// <inheritdoc />
+		public bool Remove(string key)
+		{
+			return _attributes.Remove(key);
+		}
+
+		/// <inheritdoc />
+		public bool Remove(KeyValuePair<string, CssAttribute> item)
+		{
+			if (_attributes.TryGetValue(item.Key, out var value) && value.Attribute == item.Value) {
+				return _attributes.Remove(new KeyValuePair<string, CssValue>(item.Key, value));
+			}
+
+			return false;
+		}
+
+		/// <inheritdoc />
+		public void Clear()
+		{
+			_attributes.Clear();
+		}
+
+
+		private readonly struct CssValue {
+			public int Position { get; }
+			public CssAttribute Attribute { get; }
+
+			public CssValue(int position, CssAttribute attribute)
+			{
+				Position = position;
+				Attribute = attribute;
+			}
+		}
+	}
+}

--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -100,7 +100,7 @@ namespace PreMailer.Net
 			{
 				var attribute = CssAttribute.FromRule(a);
 
-				if (attribute != null) sc.Attributes[attribute.Style] = attribute;
+				if (attribute != null) sc.Attributes.Merge(attribute);
 			}
 		}
 

--- a/PreMailer.Net/PreMailer.Net/StyleClass.cs
+++ b/PreMailer.Net/PreMailer.Net/StyleClass.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace PreMailer.Net {
@@ -8,7 +8,7 @@ namespace PreMailer.Net {
 		/// </summary>
 		public StyleClass()
 		{
-			Attributes = new Dictionary<string, CssAttribute>(StringComparer.CurrentCultureIgnoreCase);
+			Attributes = new CssAttributeCollection();
 		}
 
 		/// <summary>
@@ -26,7 +26,7 @@ namespace PreMailer.Net {
 		/// Gets or sets the attributes.
 		/// </summary>
 		/// <value>The attributes.</value>
-		public Dictionary<string, CssAttribute> Attributes { get; set; }
+		public CssAttributeCollection Attributes { get; set; }
 
 		/// <summary>
 		/// Merges the specified style class, with this instance. Styles on this instance are not overriden by duplicates in the specified styleClass.
@@ -38,7 +38,7 @@ namespace PreMailer.Net {
 				if (!Attributes.TryGetValue(item.Key, out var existing) ||
 				    canOverwrite && (!existing.Important || item.Value.Important))
 				{
-					Attributes[item.Key] = item.Value;
+					Attributes.Merge(item.Value);
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the newfound [problem case](https://github.com/milkshakesoftware/PreMailer.Net/issues/53#issuecomment-826581429) of #53.

This pull request will:
- Introduce a new public class `CssAttributeCollection`.
- Changes a Public API `StyleClass.Attributes { get; set; }` form `Dictionary<string, CssAttribute>` to `CssAttributeCollection` while CssAttributeCollection inherits from `IDictionary<string, CssAttribute>`, so there should be only a minimal breaking change.

Side effect of this change:
- Since this will keep the local order of css attributes it may also change the order of nonrelated style attributes, like: `line-height` and `font-size` as seen in `PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs`