### PR TITLE
Append analytics query string before anchor tag

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -353,6 +353,17 @@ namespace PreMailer.Net.Tests
 		}
 
 		[Fact]
+		public void AddAnalyticsTags_AddsTagsBeforeAnchorTags()
+		{
+			const string input = @"<div><a href=""https://github.com/premailer/premailer#premailer-specific-css"">Premailer Specific CSS</a></div>";
+			const string expected = @"<html><head></head><body><div><a href=""https://github.com/premailer/premailer?utm_source=source&amp;utm_medium=medium&amp;utm_campaign=campaign&amp;utm_content=content#premailer-specific-css"">Premailer Specific CSS</a></div></body></html>";
+			var premailedOutput = new PreMailer(input)
+				.AddAnalyticsTags("source", "medium", "campaign", "content", "github.com")
+				.MoveCssInline();
+			Assert.True(expected == premailedOutput.Html);
+		}
+
+		[Fact]
 		public void ContainsLinkCssElement_DownloadsCss()
 		{
 			var mockDownloader = new Mock<IWebDownloader>();

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -206,7 +206,14 @@ namespace PreMailer.Net
 				var href = tag.Attributes["href"];
 				if (href.Value.StartsWith("http", StringComparison.OrdinalIgnoreCase) && (domain == null || DomainMatch(domain, href.Value)))
 				{
-					tag.SetAttribute("href", href.Value + (href.Value.IndexOf("?", StringComparison.Ordinal) >= 0 ? "&" : "?") + tracking);
+					var hrefValue = href.Value;
+					var anchor = "";
+					if (href.Value.Contains("#"))
+					{
+						anchor = href.Value.Substring(href.Value.IndexOf("#", StringComparison.Ordinal));
+						hrefValue = hrefValue.Replace(anchor, "");
+					}
+					tag.SetAttribute("href", hrefValue + (hrefValue.IndexOf("?", StringComparison.Ordinal) >= 0 ? "&" : "?") + tracking + anchor);
 				}
 			}
 


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc3986#section-4.1 anchor tags (#) should be appended after query string params.

Issue #254 