### PR TITLE
Fix: Generate inline styles without !important (#149)

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/CssAttributeTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssAttributeTests.cs
@@ -42,6 +42,16 @@ namespace PreMailer.Net.Tests
 		}
 
 		[Fact]
+		public void ImportantRule_EmitsImportantAttributeOnlyWhenSpecified()
+		{
+			var attribute = CssAttribute.FromRule("color: red !important");
+
+			Assert.Equal("color: red", attribute.ToString());
+			Assert.Equal("color: red", attribute.ToString(emitImportant: false));
+			Assert.Equal("color: red !important", attribute.ToString(emitImportant: true));
+		}
+
+		[Fact]
 		public void ImportantRule_ReturnsValidCssWithoutWhitespaces()
 		{
 			var attribute = CssAttribute.FromRule("color:red!important");

--- a/PreMailer.Net/PreMailer.Net.Tests/StyleClassApplierTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/StyleClassApplierTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using AngleSharp.Dom;
 using AngleSharp.Html.Parser;
@@ -43,5 +43,22 @@ namespace PreMailer.Net.Tests
             Assert.Equal("<table id=\"tabletest3\" class=\"test3\" bgcolor=\"\" height=\"10px\" style=\"height: 10px\"></table>", result.ElementAt(2).Key.OuterHtml);
             Assert.Equal("<table id=\"tabletest4\" class=\"test4\" bgcolor=\"#008003\" width=\"10px\" style=\"background-color: #008003;width: 10px\"></table>", result.ElementAt(3).Key.OuterHtml);
         }
+
+		[Fact]
+		public void ApplyInlineStylesWithoutImportant()
+		{
+			var document = new HtmlParser().ParseDocument("<div></div>");
+
+			var clazz = new StyleClass();
+			clazz.Attributes["color"] = CssAttribute.FromRule("color: #000 !important");
+
+			var elementDictionary = new Dictionary<IElement, StyleClass> {
+				{document.Body.FirstElementChild, clazz}
+			};
+
+			var result = StyleClassApplier.ApplyAllStyles(elementDictionary);
+
+			Assert.Equal("<div style=\"color: #000\"></div>", result.ElementAt(0).Key.OuterHtml);
+		}
     }
 }

--- a/PreMailer.Net/PreMailer.Net.Tests/StyleClassTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/StyleClassTests.cs
@@ -117,5 +117,16 @@ namespace PreMailer.Net.Tests
             Assert.True(target.Attributes.ContainsKey("height"));
             Assert.Equal("100%", target.Attributes["height"].Value);
         }
-    }
+
+        [Fact]
+        public void Merge_ShouldEmitImportantOnlyWhenSpecified()
+        {
+			var clazz = new StyleClass();
+			clazz.Attributes["color"] = CssAttribute.FromRule("color: red !important");
+
+			Assert.Equal("color: red", clazz.ToString());
+			Assert.Equal("color: red", clazz.ToString(emitImportant: false));
+			Assert.Equal("color: red !important", clazz.ToString(emitImportant: true));
+		}
+	}
 }

--- a/PreMailer.Net/PreMailer.Net/CssAttribute.cs
+++ b/PreMailer.Net/PreMailer.Net/CssAttribute.cs
@@ -36,9 +36,22 @@ namespace PreMailer.Net
 			};
 		}
 
+		/// <inheritdoc />
 		public override string ToString()
 		{
-			return $"{Style}: {Value}{(Important ? " !important" : string.Empty)}";
+			return ToString(removeImportant: false);
+		}
+
+		/// <summary>
+		/// Generates css styles with or without !important
+		/// </summary>
+		/// <param name="removeImportant"> When set to <c>true</c> generates css styles without !important </param>
+		/// <returns> css styles with or without !important </returns>
+		public string ToString(bool removeImportant)
+		{
+			return removeImportant
+				? $"{Style}: {Value}"
+				: $"{Style}: {Value}{(Important ? " !important" : string.Empty)}";
 		}
 	}
 }

--- a/PreMailer.Net/PreMailer.Net/CssAttribute.cs
+++ b/PreMailer.Net/PreMailer.Net/CssAttribute.cs
@@ -39,19 +39,17 @@ namespace PreMailer.Net
 		/// <inheritdoc />
 		public override string ToString()
 		{
-			return ToString(removeImportant: false);
+			return ToString(emitImportant: false);
 		}
 
 		/// <summary>
 		/// Generates css styles with or without !important
 		/// </summary>
-		/// <param name="removeImportant"> When set to <c>true</c> generates css styles without !important </param>
+		/// <param name="emitImportant">When set to <c>true</c>, resulting CSS emits the !important flag.</param>
 		/// <returns> css styles with or without !important </returns>
-		public string ToString(bool removeImportant)
+		public string ToString(bool emitImportant)
 		{
-			return removeImportant
-				? $"{Style}: {Value}"
-				: $"{Style}: {Value}{(Important ? " !important" : string.Empty)}";
+			return $"{Style}: {Value}{(Important && emitImportant  ? " !important" : string.Empty)}";
 		}
 	}
 }

--- a/PreMailer.Net/PreMailer.Net/CssElementStyleResolver.cs
+++ b/PreMailer.Net/PreMailer.Net/CssElementStyleResolver.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using AngleSharp.Dom;
 
@@ -15,7 +15,7 @@ namespace PreMailer.Net
 			AddSpecialPremailerAttributes(attributeCssList, styleClass);
 
 			if (styleClass.Attributes.Count > 0)
-				attributeCssList.Add(new AttributeToCss { AttributeName = "style", CssValue = styleClass.ToString() });
+				attributeCssList.Add(new AttributeToCss { AttributeName = "style", CssValue = styleClass.ToString(removeImportant: true) });
 
 			attributeCssList.AddRange(CssStyleEquivalence.FindEquivalent(domElement, styleClass));
 

--- a/PreMailer.Net/PreMailer.Net/CssElementStyleResolver.cs
+++ b/PreMailer.Net/PreMailer.Net/CssElementStyleResolver.cs
@@ -15,7 +15,7 @@ namespace PreMailer.Net
 			AddSpecialPremailerAttributes(attributeCssList, styleClass);
 
 			if (styleClass.Attributes.Count > 0)
-				attributeCssList.Add(new AttributeToCss { AttributeName = "style", CssValue = styleClass.ToString(removeImportant: true) });
+				attributeCssList.Add(new AttributeToCss { AttributeName = "style", CssValue = styleClass.ToString() });
 
 			attributeCssList.AddRange(CssStyleEquivalence.FindEquivalent(domElement, styleClass));
 

--- a/PreMailer.Net/PreMailer.Net/StyleClass.cs
+++ b/PreMailer.Net/PreMailer.Net/StyleClass.cs
@@ -46,16 +46,16 @@ namespace PreMailer.Net {
 
 		/// <inheritdoc />
 		public override string ToString() {
-			return ToString(removeImportant: false);
+			return ToString(emitImportant: false);
 		}
 
 		/// <summary>
 		/// Generates css styles with or without !important
 		/// </summary>
-		/// <param name="removeImportant"> When set to <c>true</c> generates css styles without !important </param>
+		/// <param name="emitImportant">When set to <c>true</c>, resulting CSS emits the !important flag.</param>
 		/// <returns> css styles with or without !important </returns>
-		public string ToString(bool removeImportant) {
-			return string.Join(";", Attributes.Values.Select(_ => _.ToString(removeImportant)));
+		public string ToString(bool emitImportant) {
+			return string.Join(";", Attributes.Values.Select(_ => _.ToString(emitImportant)));
 		}
 	}
 }

--- a/PreMailer.Net/PreMailer.Net/StyleClass.cs
+++ b/PreMailer.Net/PreMailer.Net/StyleClass.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PreMailer.Net {
 	public class StyleClass {
@@ -43,14 +44,18 @@ namespace PreMailer.Net {
 			}
 		}
 
-		/// <summary>
-		/// Returns a <see cref="System.String"/> that represents this instance.
-		/// </summary>
-		/// <returns>
-		/// A <see cref="System.String"/> that represents this instance.
-		/// </returns>
+		/// <inheritdoc />
 		public override string ToString() {
-			return string.Join(";", Attributes.Values);
+			return ToString(removeImportant: false);
+		}
+
+		/// <summary>
+		/// Generates css styles with or without !important
+		/// </summary>
+		/// <param name="removeImportant"> When set to <c>true</c> generates css styles without !important </param>
+		/// <returns> css styles with or without !important </returns>
+		public string ToString(bool removeImportant) {
+			return string.Join(";", Attributes.Values.Select(_ => _.ToString(removeImportant)));
 		}
 	}
 }


### PR DESCRIPTION
This pull request removes `!important` from generated inline styles.

This change makes sense because the intention of `!important` is to overwrite inline styles,
so inline styles with `!important` have no real reason to exist.
And as seen in #149 Outlook considers inline styles with it as invalid and ignores them as a whole.

I thought about making this change configurable, but I don't see a benefit from doing so.

I hope this pull request is welcome.

Best regards