### PR TITLE
Preserve unsupported media queries in head element

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -138,6 +138,26 @@ namespace PreMailer.Net.Tests
 		}
 
 		[Fact]
+		public void MoveCssInline_PreserveMediaQueries_RemovesStyleElementsWithoutMediaQueries()
+		{
+			string input = "<html><head><style>div { width: 42px; }</style></head><body><div>test</div></body></html>";
+
+			var premailedOutput = PreMailer.MoveCssInline(input, removeStyleElements: true, preserveMediaQueries: true);
+
+			Assert.DoesNotContain("<style>", premailedOutput.Html);
+		}
+
+		[Fact]
+		public void MoveCssInline_PreserveMediaQueries_PreservesStyleElementsWithMediaQueries()
+		{
+			string input = "<html><head><style>div { width: 42px; }  @media (max-width: 250px) { div { width: 20px; } }</style></head><body><div>test</div></body></html>";
+
+			var premailedOutput = PreMailer.MoveCssInline(input, removeStyleElements: true, preserveMediaQueries: true);
+
+			Assert.Contains("<style>@media (max-width: 250px) { div { width: 20px; } }</style>", premailedOutput.Html);
+		}
+
+		[Fact]
 		public void MoveCssInline_MultipleSelectors_HonorsIndividualSpecificity()
 		{
 			string input = "<html><head><style type=\"text/css\">p,li,tr.pub-heading td,tr.pub-footer td,tr.footer-heading td { font-size: 12px; line-height: 16px; } td.disclaimer p {font-size: 11px;} </style></head><body><table><tr class=\"pub-heading\"><td class=\"disclaimer\"><p></p></td></tr></body></html>";

--- a/PreMailer.Net/PreMailer.Net/CssParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssParser.cs
@@ -128,6 +128,10 @@ namespace PreMailer.Net
 
 		public static IEnumerable<string> GetUnsupportedMediaQueries(string s)
 		{
+			if (string.IsNullOrWhiteSpace(s))
+			{
+				yield break;
+			}
 			foreach (Match match in MediaQueryRegex.Matches(s))
 			{
 				if (!SupportedMediaQueriesRegex.IsMatch(match.Value))

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -331,7 +331,7 @@ namespace PreMailer.Net
 					var unsupportedMediaQueries = CssParser.GetUnsupportedMediaQueries(node.InnerHtml);
 					if (unsupportedMediaQueries.Any())
 					{
-						node.InnerHtml = $"\n{string.Join("\n", unsupportedMediaQueries)}\n";
+						node.InnerHtml = $"{string.Join("\n", unsupportedMediaQueries)}";
 					}
 					else
 					{


### PR DESCRIPTION
Currently, if using `removeStyleElements` while also having media queries in `<style>` in `<head>` which cannot be inlined, these media queries will be lost.

This adds a new parameter `preserveMediaQueries` which instead of removing the entire `<style>` node, will replace the inner styles with just the unsupported media queries

I realise you already have a a workaround for this of setting an id on the style node and using `ignoreElements` so feel free to close this if you would prefer to keep it as is