### PR TITLE
Decent optimizations for CssAttributeCollection

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/CssParserTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/CssParserTests.cs
@@ -188,8 +188,8 @@ namespace PreMailer.Net.Tests
 
 			var attributes = parser.Styles.First().Value.Attributes.ToArray();
 
-			Assert.True(attributes[0] is {Key: "background", Value: {Value: "red"}});
-			Assert.True(attributes[1] is {Key: "background-color", Value: {Value: "green"}});
+			Assert.True(attributes[0] is {Style: "background", Value: "red"});
+			Assert.True(attributes[1] is {Style: "background-color", Value: "green" });
 		}
 
         [Fact]

--- a/PreMailer.Net/PreMailer.Net/CssElementStyleResolver.cs
+++ b/PreMailer.Net/PreMailer.Net/CssElementStyleResolver.cs
@@ -26,18 +26,18 @@ namespace PreMailer.Net
 		{
 			while (true)
 			{
-				var premailerRuleMatch = styleClass.Attributes.FirstOrDefault(a => a.Key.StartsWith(premailerAttributePrefix));
+				var premailerRuleMatch = styleClass.Attributes.FirstOrDefault(a => a.Style.StartsWith(premailerAttributePrefix));
 
-				var key = premailerRuleMatch.Key;
-				var cssAttribute = premailerRuleMatch.Value;
-
-				if (key == null)
+				if (premailerRuleMatch == null)
 					break;
+
+				var key = premailerRuleMatch.Style;
+				var cssAttribute = premailerRuleMatch.Value;
 
 				attributeCssList.Add(new AttributeToCss
 				{
 					AttributeName = key.Replace(premailerAttributePrefix, ""),
-					CssValue = cssAttribute.Value
+					CssValue = cssAttribute
 				});
 
 				styleClass.Attributes.Remove(key);

--- a/PreMailer.Net/PreMailer.Net/StyleClass.cs
+++ b/PreMailer.Net/PreMailer.Net/StyleClass.cs
@@ -36,10 +36,10 @@ namespace PreMailer.Net {
 		/// <param name="canOverwrite">if set to <c>true</c> [can overwrite].</param>
 		public void Merge(StyleClass styleClass, bool canOverwrite) {
 			foreach (var item in styleClass.Attributes) {
-				if (!Attributes.TryGetValue(item.Key, out var existing) ||
-				    canOverwrite && (!existing.Important || item.Value.Important))
+				if (!Attributes.TryGetValue(item.Style, out var existing) ||
+				    canOverwrite && (!existing.Important || item.Important))
 				{
-					Attributes.Merge(item.Value);
+					Attributes.Merge(item);
 				}
 			}
 		}
@@ -55,7 +55,7 @@ namespace PreMailer.Net {
 		/// <param name="emitImportant">When set to <c>true</c>, resulting CSS emits the !important flag.</param>
 		/// <returns> css styles with or without !important </returns>
 		public string ToString(bool emitImportant) {
-			return string.Join(";", Attributes.Values.Select(_ => _.ToString(emitImportant)));
+			return string.Join(";", Attributes.Select(_ => _.ToString(emitImportant)));
 		}
 	}
 }


### PR DESCRIPTION
### Changes
The core change is that we don't try to be a dictionary anymore, just a simple list. No need for the `CssValue` struct either, just store the `CssAttribute` directly in the list. The order of the list is the same as the attribute order, so no need to sort it every time we want to iterate over it.

Because this is a public type, these are probably considered breaking changes.

### Realistic benchmark of MoveCssInline()
One invocation of MoveCssInline()
Original: 1.2ms 592kB
After:  1.0ms 482kB
