### PR TITLE
Include a benchmark that sets all MoveCssInline() flags

### DIFF
--- a/PreMailer.Net/Benchmarks/Program.cs
+++ b/PreMailer.Net/Benchmarks/Program.cs
@@ -27,6 +27,19 @@ public class Realistic
 		PreMailer.Net.PreMailer.MoveCssInline(RawHtml);
 	}
 
+	[Benchmark]
+	public void MoveCssInline_AllFlags()
+	{
+		PreMailer.Net.PreMailer.MoveCssInline(
+			RawHtml,
+			removeStyleElements: true,
+			ignoreElements: ".container table:not(:first-child)",
+			css: "table td { color: #123 } table.body-wrap { width: 10%;}",
+			stripIdAndClassAttributes: true,
+			removeComments: true,
+			preserveMediaQueries: true);
+	}
+
 	private static readonly string RawHtml = @"
 <html xmlns=""http://www.w3.org/1999/xhtml"">
 <head>


### PR DESCRIPTION
It looks a bit different from the default one because it triggers various features.

There is no special magic with the strings, it's just intended to properly trigger the corresponding feature.

|                 Method |     Mean |   Error |   StdDev |   Median |    Gen0 | Allocated |
|----------------------- |---------:|--------:|---------:|---------:|--------:|----------:|
|     AngleSharpBaseline | 170.2 us | 6.44 us | 19.00 us | 162.8 us |       - | 138.43 KB |
|          MoveCssInline | 826.6 us | 4.63 us | 12.44 us | 825.3 us | 30.0000 | 621.16 KB |
| MoveCssInline_AllFlags | 895.0 us | 5.60 us | 15.90 us | 892.0 us | 30.0000 | 634.99 KB |