### PR TITLE
Read text node instead of InnerHtml for CSS

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/Extensions/NodeExtensionTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/Extensions/NodeExtensionTests.cs
@@ -1,0 +1,75 @@
+﻿#nullable enable
+
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AngleSharp.Html.Parser;
+using PreMailer.Net.Extensions;
+using Xunit;
+
+namespace PreMailer.Net.Tests.Extensions
+{
+	public class NodeExtensionTests
+	{
+		private static readonly IHtmlDocument _document = new HtmlParser().ParseDocument("");
+
+		private IElement Div() => _document.CreateElement("div");
+
+		private IText Text(string data) => _document.CreateTextNode(data);
+
+		[Fact]
+		public void GetClosestTextNodeData_WithNoChild_GetsNull()
+		{
+			var target = Div();
+
+			var data = target.GetFirstTextNodeData();
+
+			Assert.Null(data);
+		}
+
+		[Fact]
+		public void GetClosestTextNodeData_WithNoTextChild_GetsNull()
+		{
+			var target = Div();
+			target.AppendChild(Div());
+
+			var data = target.GetFirstTextNodeData();
+
+			Assert.Null(data);
+		}
+
+		[Fact]
+		public void GetClosestTextNodeData_WithSingleTextChild_GetsData()
+		{
+			var target = Div();
+			target.AppendChild(Text("somedata"));
+
+			var data = target.GetFirstTextNodeData();
+
+			Assert.Equal("somedata", data);
+		}
+
+		[Fact]
+		public void GetClosestTextNodeData_WithMixedChildren_GetsData()
+		{
+			var target = Div();
+			target.AppendChild(Div());
+			target.AppendChild(Text("somedata"));
+
+			var data = target.GetFirstTextNodeData();
+
+			Assert.Equal("somedata", data);
+		}
+
+		[Fact]
+		public void GetClosestTextNodeData_WithMultipleTextChildren_GetsDataOfFirst()
+		{
+			var target = Div();
+			target.AppendChild(Text("somedata1"));
+			target.AppendChild(Text("somedata2"));
+
+			var data = target.GetFirstTextNodeData();
+
+			Assert.Equal("somedata1", data);
+		}
+	}
+}

--- a/PreMailer.Net/PreMailer.Net/Extensions/NodeExtensions.cs
+++ b/PreMailer.Net/PreMailer.Net/Extensions/NodeExtensions.cs
@@ -1,0 +1,21 @@
+﻿#nullable enable
+
+using AngleSharp.Dom;
+
+namespace PreMailer.Net.Extensions
+{
+	public static class NodeExtensions
+	{
+		/// <summary>
+		/// Get the text data from the first text node child of this node.
+		/// This avoids the serialization overhead of <see cref="IElement.InnerHtml" /> and <see cref="INode.TextContent" />.
+		/// Useful for getting CSS from a STYLE element.
+		/// </summary>
+		/// <param name="node">The node from where to start the search for a <see cref="IText" />.</param>
+		/// <returns>The contents of the first text node, or null if none were found.</returns>
+		public static string? GetFirstTextNodeData(this INode node)
+		{
+			return node.FindChild<IText>()?.Data;
+		}
+	}
+}

--- a/PreMailer.Net/PreMailer.Net/PreMailer.Net.csproj
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.Net.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+	<LangVersion>latest</LangVersion>
     <Version>2.4.0</Version>
     <Authors>Martin H. Normark</Authors>
     <Description>
@@ -26,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\icon.png" Pack="true" PackagePath="\"/>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\icon.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -4,6 +4,7 @@ using AngleSharp.Html;
 using AngleSharp.Html.Dom;
 using AngleSharp.Html.Parser;
 using AngleSharp.Xhtml;
+using PreMailer.Net.Extensions;
 using PreMailer.Net.Sources;
 using System;
 using System.Collections.Generic;
@@ -328,7 +329,8 @@ namespace PreMailer.Net
 			{
 				if (preserveMediaQueries)
 				{
-					var unsupportedMediaQueries = CssParser.GetUnsupportedMediaQueries(node.FindChild<IText>()?.Data);
+					var css = node.GetFirstTextNodeData();
+					var unsupportedMediaQueries = CssParser.GetUnsupportedMediaQueries(css);
 					if (unsupportedMediaQueries.Any())
 					{
 						node.InnerHtml = $"{string.Join("\n", unsupportedMediaQueries)}";

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -328,7 +328,7 @@ namespace PreMailer.Net
 			{
 				if (preserveMediaQueries)
 				{
-					var unsupportedMediaQueries = CssParser.GetUnsupportedMediaQueries(node.InnerHtml);
+					var unsupportedMediaQueries = CssParser.GetUnsupportedMediaQueries(node.FindChild<IText>()?.Data);
 					if (unsupportedMediaQueries.Any())
 					{
 						node.InnerHtml = $"{string.Join("\n", unsupportedMediaQueries)}";

--- a/PreMailer.Net/PreMailer.Net/Sources/DocumentStyleTagCssSource.cs
+++ b/PreMailer.Net/PreMailer.Net/Sources/DocumentStyleTagCssSource.cs
@@ -1,4 +1,5 @@
 ﻿using AngleSharp.Dom;
+using PreMailer.Net.Extensions;
 
 namespace PreMailer.Net.Sources
 {
@@ -13,7 +14,7 @@ namespace PreMailer.Net.Sources
 
 		public string GetCss()
 		{
-			return _node.FindChild<IText>()?.Data ?? "";
+			return _node.GetFirstTextNodeData() ?? "";
 		}
 	}
 }

--- a/PreMailer.Net/PreMailer.Net/Sources/DocumentStyleTagCssSource.cs
+++ b/PreMailer.Net/PreMailer.Net/Sources/DocumentStyleTagCssSource.cs
@@ -13,7 +13,7 @@ namespace PreMailer.Net.Sources
 
 		public string GetCss()
 		{
-			return _node.InnerHtml;
+			return _node.FindChild<IText>()?.Data ?? "";
 		}
 	}
 }


### PR DESCRIPTION
Because reading `InnerHtml` causes serialization to HTML, with some overhead. Reading the raw data from the text node has no overhead.

A small but easy win for allocations.

#### Before (`master`)
|                 Method |     Mean |   Error |   StdDev |   Median |    Gen0 | Allocated |
|----------------------- |---------:|--------:|---------:|---------:|--------:|----------:|
|     AngleSharpBaseline | 170.2 us | 6.44 us | 19.00 us | 162.8 us |       - | 138.43 KB |
|          MoveCssInline | 826.6 us | 4.63 us | 12.44 us | 825.3 us | 30.0000 | 621.16 KB |
| MoveCssInline_AllFlags | 895.0 us | 5.60 us | 15.90 us | 892.0 us | 30.0000 | 634.99 KB |


#### After this PR
|                 Method |     Mean |   Error |   StdDev |   Median |    Gen0 | Allocated |
|----------------------- |---------:|--------:|---------:|---------:|--------:|----------:|
|     AngleSharpBaseline | 175.7 us | 8.17 us | 24.10 us | 167.3 us |       - | 138.43 KB |
|          MoveCssInline | 833.6 us | 3.50 us |  9.48 us | 832.8 us | 30.0000 | 609.12 KB |
| MoveCssInline_AllFlags | 891.2 us | 4.49 us | 12.15 us | 891.7 us | 30.0000 | 617.41 KB |