### PR TITLE
Add `&copy;` to remains HTML encoding test case

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/AngleSharpTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/AngleSharpTests.cs
@@ -1,0 +1,21 @@
+﻿using AngleSharp;
+using AngleSharp.Html.Parser;
+using Xunit;
+
+namespace PreMailer.Net.Tests;
+
+public class AngleSharpTests
+{
+	[Fact]
+	public void HtmlDocument_ToHtml_ShouldNotEffectHtmlEntities()
+	{
+		string htmlEncoded = "&lt;&amp;&gt;&nbsp;&copy;";
+		string input = $"<html><head></head><body><div>{htmlEncoded}</div></body></html>";
+		var document = new HtmlParser(new HtmlParserOptions()
+		{
+			IsNotConsumingCharacterReferences = true
+		}).ParseDocument(input);
+		var output = document.ToHtml();
+		Assert.Equal<object>(input, output); // use object to get full string output
+	}
+}

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -643,7 +643,7 @@ p
 		[Fact]
 		public void MoveCssInline_GivenHtmlEncodedCharacters_RemainsEncoded()
 		{
-			string htmlEncoded = "&lt;&amp;&gt;&nbsp;";
+			string htmlEncoded = "&lt;&amp;&gt;&nbsp;&copy;";
 			string input = $"<html><head></head><body><div>{htmlEncoded}</div></body></html>";
 			var premailedOutput = PreMailer.MoveCssInline(input);
 


### PR DESCRIPTION
`&copy;` HTML entity gets decoded to © as mentioned in #347.