### PR TITLE
Fix race condition when running unit tests

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/AssemblyInfo.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
xUnit by default will parallelize tests between tests collections (classes). The WebDownloader.SharedDownloader property was being set between multiple collections causing a race condition on which SharedDownloader object was used. This caused the first test to fail because it ran a validation against another mock object for another test.