### PR TITLE
A warning when a css resource could not be downloaded & apply styles only to elements within (and itself) the body

### DIFF
--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -247,7 +247,19 @@ namespace PreMailer.Net
 		/// </summary>
 		private IEnumerable<string> GetCssBlocks(IEnumerable<ICssSource> cssSources)
 		{
-			return cssSources.Select(styleSource => styleSource.GetCss()).ToList();
+			return cssSources.Select(GetCssBlock).ToList();
+		}
+		private string GetCssBlock(ICssSource cssSource)
+		{
+			try
+			{
+				return cssSource.GetCss();
+			}
+			catch (Exception ex)
+			{
+				_warnings.Add(ex.Message);
+				return string.Empty;
+			}
 		}
 
 		private void RemoveCssComments(IEnumerable<IElement> cssSourceNodes)

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -405,7 +405,7 @@ namespace PreMailer.Net
 				Selector = selectorParser.ParseSelector(x.Value.Name)
 			}).Where(x => x.Selector != null).ToList();
 
-			foreach (var el in _document.DescendentsAndSelf<IElement>())
+			foreach (var el in _document.Body.DescendentsAndSelf<IElement>())
 			{
 				foreach (var style in styles)
 				{

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -417,7 +417,7 @@ namespace PreMailer.Net
 				Selector = selectorParser.ParseSelector(x.Value.Name)
 			}).Where(x => x.Selector != null).ToList();
 
-			foreach (var el in _document.Body.DescendentsAndSelf<IElement>())
+			foreach (var el in _document.DescendentsAndSelf<IElement>())
 			{
 				foreach (var style in styles)
 				{


### PR DESCRIPTION
- Let GetCssBlocks add a warning to the list instead of throwing an exception when a resource could not be downloaded.

- With an All (*) selector in the stylesheet, the css rule is also applied to the html element, head element and elements in the head like script, link etc. To avoid this behaviour only the elements from the body (and itself) are selected to be matched.

Maybe there is another way not to match the all selector to the elements above the body, but this was a quick fix for us.
