### PR TITLE
Ensure external sources for styles only process CSS responses when inlining stylesheets

### DIFF
--- a/PreMailer.Net/Benchmarks/Program.cs
+++ b/PreMailer.Net/Benchmarks/Program.cs
@@ -1,17 +1,30 @@
 ﻿using AngleSharp;
 using AngleSharp.Html.Parser;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 
 public static class Program
 {
 	public static void Main()
 	{
-		BenchmarkRunner.Run<Realistic>();
+		// Some local environments may run into issues with Windows Defender or 
+		// SentinelOne (and others) when running a benchmark. This ensures we
+		// keep our toolchain within our process and stops the above apps from blocking
+		// our benchmark process, but can slow the execution time.
+		var avSafeConfig = DefaultConfig.Instance
+			.AddJob(
+				Job.ShortRun
+					.WithToolchain(InProcessNoEmitToolchain.Instance)
+					.WithIterationCount(100)
+			);
+
+		BenchmarkRunner.Run<Realistic>(avSafeConfig);
 	}
 }
 
-[SimpleJob(invocationCount: 100, iterationCount: 100)]
 [MemoryDiagnoser]
 public class Realistic
 {
@@ -47,7 +60,7 @@ public class Realistic
 
 <meta http-equiv=""Content-Type"" content=""text/html; charset=UTF-8"" />
 <title>PreMailer Benchmark</title>
-	
+
 </head>
  
 <body bgcolor=""#123"">

--- a/PreMailer.Net/PreMailer.Net/Downloaders/WebDownloader.cs
+++ b/PreMailer.Net/PreMailer.Net/Downloaders/WebDownloader.cs
@@ -1,3 +1,4 @@
+using PreMailer.Net.Extensions;
 using System;
 using System.IO;
 using System.Net;
@@ -8,7 +9,7 @@ namespace PreMailer.Net.Downloaders
 	public class WebDownloader : IWebDownloader
 	{
 		private static IWebDownloader _sharedDownloader;
-
+		private const string CssMimeType = "text/css";
 		public static IWebDownloader SharedDownloader
 		{
 			get
@@ -29,8 +30,16 @@ namespace PreMailer.Net.Downloaders
 		public string DownloadString(Uri uri)
 		{
 			var request = WebRequest.Create(uri);
+			request.Headers.Add(HttpRequestHeader.Accept, CssMimeType);
+
 			using (var response = request.GetResponse())
 			{
+				// We only support this operation for CSS file/content types coming back
+				// from the response. If we get something different, throw with the unsupported
+				// content type in the message
+				if(response.ParseContentType() != CssMimeType)
+					throw new NotSupportedException($"The Uri type is giving a response in unsupported content type '{response.ContentType}'.");
+
 				switch (response)
 				{
 					case HttpWebResponse httpWebResponse:

--- a/PreMailer.Net/PreMailer.Net/Extensions/WebResponseExtensions.cs
+++ b/PreMailer.Net/PreMailer.Net/Extensions/WebResponseExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Net;
+
+namespace PreMailer.Net.Extensions
+{
+	public static class WebResponseExtensions
+	{
+		public static string ParseContentType(this WebResponse response)
+		{
+			if(response == null)
+				throw new NullReferenceException("Malformed response detected when parsing WebResponse Content-Type");
+
+			if(string.IsNullOrEmpty(response.ContentType))
+				throw new NullReferenceException("Malformed Content-Type response detected when parsing WebResponse");
+
+			var results = response.ContentType.Split(';');
+
+			if(results.Length == 0)
+				throw new FormatException("Malformed Content-Type response detected when parsing WebResponse");
+
+			return results[0];
+		}
+	}
+}


### PR DESCRIPTION
# Background

This fix relates to issues when a HTML template contains a `<link>` node that points at a resource which returns something that *isn't* a CSS stylesheet. We had a user which created a HTML template (that we render and serve, hence the need to inline stylesheets), which managed to spike CPU usage on our Azure App Service Plan to 100%, with no end in sight. It simply just peaked there, and kept spinning, bringing several other apps on the same App Service Plan down and/or non-responsive.

We ran a .NET trace on the Azure App Service to try and figure out where the issue was coming from, and we came across [this](https://github.com/milkshakesoftware/PreMailer.Net/issues/233) issue which seemed to match up with what we were seeing, at least on the surface.

![image](https://github.com/user-attachments/assets/2be6083f-f55e-411d-9342-c647bc32b52d)

Once we dug into it a bit more, we realized the template had a `<link>` node defined that once evaluated by the PreMailer.Net library, would result in a Content-Type return value of `text/html`. It was returning plain HTML which seemed to be throwing the Regex parsers for a loop! 

The dodgy `<link>` in question was pointing at a resource that would only return actual CSS (what PreMailer.Net would normally expect), if we set the `Accept` header to `text/css`, to force the server to return the CSS string. Otherwise it would render the "normal" HTML page, as if you'd navigated to it via a browser.

So the fix for this is fairly straightforward, where we ensure the `Accept` headers for the `WebDownloader.DownloadString` method are added to specifically only request CSS content, and we check the response `Content-Type` and ensure that matches CSS content too, and throw if we detect something different.

Open to feedback on any other/cleaner ways of fixing this :)

# Changes

- Updated `WebDownloader.DownloadString` to set the `Accept` request header for CSS stylesheets
- Updated `WebDownloader.DownloadString` to check the response and ensure the `Content-Type` matches the CSS Content-Type.
- Introduced an extension method to parse the `Content-Type` response header, to make checking/comparing the response headers a bit easier.
- Updated the `Benchmarks.Program` class to use a potentially safer method of benchmarking our code, where we create a config on the fly that uses `InProcessNoEmitToolchain` to prevent our Benchmarks from spawning too many threads/processes.
    * This was a really strange one. See "Questions" below.

# Questions

- What would be a good way of testing this? I noticed that most areas that potentially use `IWebDownloader` implementations tend to be mocked/stubbed out, so given most of my changes live in the `WebDownloader` itself, I'd love some guidance on how you'd want me to test this.
- Did you want me to roll back the `InProcessNoEmitToolchain` configuration changes in the Benchmarker project? 
    *  I had my work anti-virus application flag the Benchmark app as suspicious, and it would prevent the benchmark from running *at all*. I'm happy to revert this bit if you don't find it useful.
- Are you happy with the types of `Exception`s I'm throwing? I wasn't entirely sure if throwing was the correct way forward for how we normally handle issues like this within PreMailer.Net, so I'm also open to feedback on changing this to something other than Exceptions being thrown everywhere :)
