### PR TITLE
Update target frameworks of test and benchmark projects

### DIFF
--- a/PreMailer.Net/Benchmarks/Benchmarks.csproj
+++ b/PreMailer.Net/Benchmarks/Benchmarks.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailer.Net.Tests.csproj
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailer.Net.Tests.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request includes updates to the target framework and package references for the `PreMailer.Net` project. This will address the failing tests.

The most important changes are as follows:

Framework updates:
* Updated the target framework from `net7.0` to `net9.0` in `PreMailer.Net/Benchmarks/Benchmarks.csproj`.
* Updated the target framework from `net7.0` to `net9.0` in `PreMailer.Net/PreMailer.Net.Tests/PreMailer.Net.Tests.csproj`.

Package reference updates:
* Updated `BenchmarkDotNet` from version `0.13.3` to `0.14.0` in `PreMailer.Net/Benchmarks/Benchmarks.csproj`.
* Updated several package references in `PreMailer.Net/PreMailer.Net.Tests/PreMailer.Net.Tests.csproj`:
  * `Microsoft.NET.Test.Sdk` from version `17.9.0` to `17.12.0`
  * `Moq` from version `4.20.70` to `4.20.72`
  * `xunit` from version `2.7.0` to `2.9.3`
  * `xunit.runner.visualstudio` from version `2.5.7` to `3.0.1`
  * `coverlet.collector` from version `6.0.2` to `6.0.4`