### PR TITLE
Upgrade CI to .NET 10

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5.2.0
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 10.0.x
 
       - name: Install dependencies
         working-directory: ./PreMailer.Net

--- a/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
+++ b/PreMailer.Net/PreMailer.Net/CssSelectorParser.cs
@@ -159,7 +159,7 @@ namespace PreMailer.Net
 					"valid",
 					"visited"
 				}
-				.Reverse().ToArray(); // NOTE: Reversal is important to ensure 'first-line' is processed before 'first'.
+				.AsEnumerable().Reverse().ToArray(); // NOTE: Reversal is important to ensure 'first-line' is processed before 'first'.
 			}
 		}
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ This is useful for advanced scenarios where you need to modify the HTML structur
 ## Installation
 **NuGet**: [PreMailer.Net](http://nuget.org/List/Packages/PreMailer.Net)
 
+## GitHub Actions locally
+Run locally using **act**:
+
+```bash
+act push --container-architecture=linux/arm64 --platform ubuntu-slim=node:lts-bullseye
+```
+
 ## Contributors
 
 * [martinnormark](https://github.com/martinnormark)


### PR DESCRIPTION
## Summary
- Upgrade the CI workflow dotnet-version from 3.1.101 to 10.0.x to build and test against .NET 10.